### PR TITLE
Bug fix: C1 should not allocate x3, which is the gp register

### DIFF
--- a/src/hotspot/cpu/riscv64/c1_Defs_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/c1_Defs_riscv64.hpp
@@ -48,7 +48,7 @@ enum {
   pd_nof_caller_save_fpu_regs_frame_map = 32, // number of float registers killed by calls
 
   pd_first_callee_saved_reg = pd_nof_caller_save_cpu_regs_frame_map,
-  pd_last_callee_saved_reg = 22,
+  pd_last_callee_saved_reg = 21,
 
   pd_last_allocatable_cpu_reg = pd_nof_caller_save_cpu_regs_frame_map - 1,
 

--- a/src/hotspot/cpu/riscv64/c1_Defs_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/c1_Defs_riscv64.hpp
@@ -44,7 +44,7 @@ enum {
   pd_nof_fpu_regs_frame_map = FloatRegisterImpl::number_of_registers,  // number of float registers used during code emission
 
   // caller saved
-  pd_nof_caller_save_cpu_regs_frame_map = 14, // number of registers killed by calls
+  pd_nof_caller_save_cpu_regs_frame_map = 13, // number of registers killed by calls
   pd_nof_caller_save_fpu_regs_frame_map = 32, // number of float registers killed by calls
 
   pd_first_callee_saved_reg = pd_nof_caller_save_cpu_regs_frame_map,

--- a/src/hotspot/cpu/riscv64/c1_FrameMap_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_FrameMap_riscv64.cpp
@@ -182,6 +182,7 @@ LIR_Opr FrameMap::_caller_save_fpu_regs[] = { 0, };
 // |---x23--|
 // |---x8---|
 // |---x4---|
+// |---x3---|
 // |---x2---|
 // |---x1---|
 // |---x0---|
@@ -196,7 +197,6 @@ LIR_Opr FrameMap::_caller_save_fpu_regs[] = { 0, };
 // |---..---|
 // |---x10--|
 // |---x7---|
-// |---x3---|
 
 void FrameMap::initialize() {
   assert(!_init_done, "once");

--- a/src/hotspot/cpu/riscv64/c1_FrameMap_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_FrameMap_riscv64.cpp
@@ -204,7 +204,6 @@ void FrameMap::initialize() {
   int i = 0;
 
   // caller save register
-  map_register(i, x3);  r3_opr  = LIR_OprFact::single_cpu(i); i++;
   map_register(i, x7);  r7_opr  = LIR_OprFact::single_cpu(i); i++;
   map_register(i, x10); r10_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, x11); r11_opr = LIR_OprFact::single_cpu(i); i++;
@@ -234,6 +233,7 @@ void FrameMap::initialize() {
   map_register(i, x0);  zr_opr  = LIR_OprFact::single_cpu(i); i++;  // zr
   map_register(i, x1);  r1_opr  = LIR_OprFact::single_cpu(i); i++;  // lr
   map_register(i, x2);  r2_opr  = LIR_OprFact::single_cpu(i); i++;  // sp
+  map_register(i, x3);  r3_opr  = LIR_OprFact::single_cpu(i); i++;  // gp
   map_register(i, x4);  r4_opr  = LIR_OprFact::single_cpu(i); i++;  // thread
   map_register(i, x8);  r8_opr  = LIR_OprFact::single_cpu(i); i++;  // fp
   map_register(i, x23); r23_opr = LIR_OprFact::single_cpu(i); i++;  // java thread
@@ -255,7 +255,6 @@ void FrameMap::initialize() {
   fpu10_double_opr  = LIR_OprFact::double_fpu(10);
 
   i = 0;
-  _caller_save_cpu_regs[i++]  = r3_opr;
   _caller_save_cpu_regs[i++]  = r7_opr;
   _caller_save_cpu_regs[i++]  = r10_opr;
   _caller_save_cpu_regs[i++]  = r11_opr;

--- a/src/hotspot/cpu/riscv64/c1_Runtime1_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_Runtime1_riscv64.cpp
@@ -249,7 +249,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
 
   // cpu_regs, caller save registers only, see FrameMap::initialize
   // in c1_FrameMap_riscv64.cpp for detail.
-  const static Register caller_save_cpu_regs[FrameMap::max_nof_caller_save_cpu_regs] = {x3, x7, x10, x11, x12,
+  const static Register caller_save_cpu_regs[FrameMap::max_nof_caller_save_cpu_regs] = {x7, x10, x11, x12,
                                                                                         x13, x14, x15, x16, x17,
                                                                                         x28,  x29, x30, x31};
   for (int i = 0; i < FrameMap::max_nof_caller_save_cpu_regs; i++) {


### PR DESCRIPTION
Hi team,

We found that in our implementation `x3` (which is also the `gp` register) could be allocated in compiled code of C1, but not of C2. Simply this patch disables the allocation of `x3` register to make sure it works when users use a JNI program (which has global variables) to access a VM; in this condition, the allocation of `x3` will violate global variables written by users (which are accessed by the `x3` register) and hence causing a crash. The reproducible test is at below:
[The test (on Github gist) reproducing the issue](https://gist.github.com/zhengxiaolinX/906687f484f5f991c21f5bc7e83c74f4)

Thanks,
Xiaolin