### PR TITLE
[macroassembler] implement tls function MacroAssembler::get_thread() using tls.ie

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv64/threadLS_linux_riscv64.S
+++ b/src/hotspot/os_cpu/linux_riscv64/threadLS_linux_riscv64.S
@@ -1,0 +1,43 @@
+// Copyright (c) 2015, Red Hat Inc. All rights reserved.
+// Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+
+        // JavaThread::riscv64_get_thread_helper()
+        //
+        // Return the current thread pointer in a0(x10).
+        // All other registers are preserved,
+
+    .global _ZN10JavaThread25riscv64_get_thread_helperEv
+    .type   _ZN10JavaThread25riscv64_get_thread_helperEv, %function
+
+_ZN10JavaThread25riscv64_get_thread_helperEv:
+    addi    sp, sp, -16
+    sd      ra, 8(sp)
+    sd      s0, 0(sp)
+    la.tls.ie a0, _ZN6Thread12_thr_currentE
+    add     a0, a0, tp
+    ld      a0, 0(a0)
+    ld      ra, 8(sp)
+    ld      s0, 0(sp)
+    addi    sp, sp, 16
+    ret
+
+    .size _ZN10JavaThread25riscv64_get_thread_helperEv, .-_ZN10JavaThread25riscv64_get_thread_helperEv

--- a/src/hotspot/os_cpu/linux_riscv64/threadLS_linux_riscv64.S
+++ b/src/hotspot/os_cpu/linux_riscv64/threadLS_linux_riscv64.S
@@ -29,15 +29,9 @@
     .type   _ZN10JavaThread25riscv64_get_thread_helperEv, %function
 
 _ZN10JavaThread25riscv64_get_thread_helperEv:
-    addi    sp, sp, -16
-    sd      ra, 8(sp)
-    sd      s0, 0(sp)
     la.tls.ie a0, _ZN6Thread12_thr_currentE
     add     a0, a0, tp
     ld      a0, 0(a0)
-    ld      ra, 8(sp)
-    ld      s0, 0(sp)
-    addi    sp, sp, 16
     ret
 
     .size _ZN10JavaThread25riscv64_get_thread_helperEv, .-_ZN10JavaThread25riscv64_get_thread_helperEv

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -165,8 +165,4 @@ inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 //
 #define ATTRIBUTE_ALIGNED(x) __attribute__((aligned(x)))
 
-#if defined(RISCV64)
-#define USE_LIBRARY_BASED_TLS_ONLY 1
-#endif
-
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_GCC_HPP


### PR DESCRIPTION
Hi team,

This patch fixes the unimplemented `__ get_thread()`, which can bring some performance improvement by directly using the `x4` register to refer to the variable `Thread::_thr_current`.
I was wondering if you could take a look at this patch when available.

Thanks,
Xiaolin

