### PR TITLE
[Compressed Instructions] Support compressed instructions for RVC

### DIFF
--- a/src/hotspot/cpu/riscv64/assembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/assembler_riscv64.cpp
@@ -34,9 +34,377 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "nativeInst_riscv64.hpp"
 
 int AbstractAssembler::code_fill_byte() {
   return 0;
+}
+
+// C-Ext: Compressed Instructions
+#define FUNC(NAME, funct3, bits)                                                   \
+  bool Assembler::NAME(Register rs1, Register rd_rs2, int32_t imm12, bool ld) {    \
+    return rs1 == sp &&                                                            \
+      is_unsigned_imm_in_range(imm12, bits, 0) &&                                  \
+      (intx(imm12) & funct3) == 0x0 &&                                             \
+      (!ld || rd_rs2 != x0);                                                       \
+  }                                                                                \
+
+  FUNC(is_cldsdsp,  0b111, 9);
+  FUNC(is_clwswsp,  0b011, 8);
+
+#undef FUNC
+
+#define FUNC(NAME, funct3, bits)                                                   \
+  bool Assembler::NAME(Register rs1, Register rd_rs2, int32_t imm12) {             \
+    return rs1->is_compressed_valid() &&                                           \
+      rd_rs2->is_compressed_valid() &&                                             \
+      is_unsigned_imm_in_range(imm12, bits, 0) &&                                  \
+      (intx(imm12) & funct3) == 0x0;                                               \
+  }                                                                                \
+
+  FUNC(is_cldsd,  0b111, 8);
+  FUNC(is_clwsw,  0b011, 7);
+
+#undef FUNC
+
+bool Assembler::emit_compressed_ld_st(unsigned int insn, bool ld) {
+  uint32_t funct3 = Assembler::extract(insn, 14, 12);
+  uint32_t rs1_bits = Assembler::extract(insn, 19, 15);
+  uint32_t rd_rs2_bits = 0;
+  int32_t imm12 = 0;
+  if (ld) {
+    rd_rs2_bits = Assembler::extract(insn, 11, 7);
+    imm12 = Assembler::sextract(insn, 31, 20);
+  } else {
+    rd_rs2_bits = Assembler::extract(insn, 24, 20);
+    imm12 = Assembler::sextract(insn, 31, 25);
+    imm12 = (imm12 << 5) | Assembler::extract(insn, 11, 7);
+  }
+  guarantee(is_imm_in_range(imm12, 12, 0), "must be");
+  Register rs1 = as_Register(rs1_bits);
+  Register rd_rs2 = as_Register(rd_rs2_bits);
+  if (funct3 == 0b011) {  // ld/sd
+    // ld/sd(Rd, Address(sp, 8n)), which n >= 0
+    if (is_cldsdsp(rs1, rd_rs2, imm12, ld)) {
+      if (ld) {
+        c_ldsp(rd_rs2, imm12);
+      } else {
+        c_sdsp(rd_rs2, imm12);
+      }
+      return true;
+    } else
+    // ld/sd(compressed_Rd, Address(compressed_Rs, 8n)), which n >= 0
+    if (is_cldsd(rs1, rd_rs2, imm12)) {
+      if (ld) {
+        c_ld(rd_rs2, rs1, imm12);
+      } else {
+        c_sd(rd_rs2, rs1, imm12);
+      }
+      return true;
+    }
+  } else if (funct3 == 0b010) {  // lw
+    // lw/sw(Rd, Address(sp, 4n)), which n >= 0
+    if (is_clwswsp(rs1, rd_rs2, imm12, ld)) {
+      if (ld) {
+        c_lwsp(rd_rs2, imm12);
+      } else {
+        c_swsp(rd_rs2, imm12);
+      }
+      return true;
+    } else
+    // lw/sw(compressed_Rd, Address(compressed_Rs1, 4n)), which n >= 0
+    if (is_clwsw(rs1, rd_rs2, imm12)) {
+      if (ld) {
+        c_lw(rd_rs2, rs1, imm12);
+      } else {
+        c_sw(rd_rs2, rs1, imm12);
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Assembler::emit_compressed_fld_fst(unsigned int insn, bool ld) {
+  uint32_t funct3 = Assembler::extract(insn, 14, 12);
+  uint32_t rs1 = Assembler::extract(insn, 19, 15);
+  uint32_t rd_rs2 = 0;
+  int32_t imm12 = 0;
+  if (ld) {
+    rd_rs2 = Assembler::extract(insn, 11, 7);
+    imm12 = Assembler::sextract(insn, 31, 20);
+  } else {
+    rd_rs2 = Assembler::extract(insn, 24, 20);
+    imm12 = Assembler::sextract(insn, 31, 25);
+    imm12 = (imm12 << 5) | Assembler::extract(insn, 11, 7);
+  }
+  guarantee(is_imm_in_range(imm12, 12, 0), "must be");
+  if (funct3 == 0b011) {  // fld/fsd
+    // fld/fsd(Rd, Address(sp, 8n)), which n >= 0
+    if (as_Register(rs1) == sp &&
+        is_unsigned_imm_in_range(imm12, 9, 0) &&
+        (intx(imm12) & 0b111) == 0x0
+        ) {
+      if (ld) {
+        c_fldsp(as_FloatRegister(rd_rs2), imm12);
+      } else {
+        c_fsdsp(as_FloatRegister(rd_rs2), imm12);
+      }
+      return true;
+    } else
+    // ld/sd(compressed_Rd, Address(compressed_Rs, 8n)), which n >= 0
+    if (as_Register(rs1)->is_compressed_valid() &&
+        as_FloatRegister(rd_rs2)->is_compressed_valid() &&
+        is_unsigned_imm_in_range(imm12, 8, 0) &&
+        (intx(imm12) & 0b111) == 0x0
+        ) {
+      if (ld) {
+        c_fld(as_FloatRegister(rd_rs2), as_Register(rs1), imm12);
+      } else {
+        c_fsd(as_FloatRegister(rd_rs2), as_Register(rs1), imm12);
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+// C-Ext: here is our implicit phase to emit compressed instruction.
+//   We will hook instructions emitted from Assembler::emit_may_compress()
+//   and see if it can do some compression - if able to, then
+//   we will emit a 16-bit compressed instruction instead of the 32-bit
+//   instruction. All below logic follows Chapter -
+//   "C" Standard Extension for Compressed Instructions, Version 2.0.
+//   We can get performance improvement and code size reduction with this,
+//   considering the code density increment and reduction of instruction size.
+bool Assembler::emit_compressed_instruction(unsigned insn) {
+  if (!UseCExt) {
+    return false;
+  }
+
+  uint32_t opcode = Assembler::extract(insn, 6, 0);
+  if (opcode == 0b0010011) {
+    uint32_t funct3 = Assembler::extract(insn, 14, 12);
+    uint32_t rs1 = Assembler::extract(insn, 19, 15);
+    uint32_t rd = Assembler::extract(insn, 11, 7);
+    if (funct3 == 0b000) {  // addi
+      if (as_Register(rs1) == sp) {
+        int32_t imm12 = Assembler::sextract(insn, 31, 20);
+        if (imm12 != 0 && is_imm_in_range(imm12, 10, 0) &&
+            rd == rs1 && (imm12 & 0b1111) == 0x0) {
+          c_addi16sp(imm12);
+          return true;
+        }
+        uint32_t uimm12 = Assembler::extract(insn, 31, 20);
+        if (uimm12 != 0 && is_unsigned_imm_in_range(uimm12, 10, 0)
+            && rd != rs1 && as_Register(rd)->is_compressed_valid() && (uimm12 & 0b11) == 0x0) {
+          c_addi4spn(as_Register(rd), uimm12);
+          return true;
+        }
+      }
+      int32_t imm12 = Assembler::sextract(insn, 31, 20);
+      guarantee(is_imm_in_range(imm12, 12, 0), "must be");
+      if (imm12 == 0 && as_Register(rd) != x0 && as_Register(rs1) != x0) {
+        c_mv(as_Register(rd), as_Register(rs1));
+        return true;
+      } else if (rd == rs1 && is_imm_in_range(imm12, 6, 0)) { // [-32, 31]
+        if (as_Register(rd) != x0) {
+          c_addi(as_Register(rd), imm12);
+        } else if (imm12 == 0) {
+          c_nop();
+        }
+        return true;
+      }
+    } else if (funct3 == 0b111) {  // andi
+      int32_t imm12 = Assembler::sextract(insn, 31, 20);
+      guarantee(is_imm_in_range(imm12, 12, 0), "must be");
+      if (rd == rs1 && is_imm_in_range(imm12, 6, 0) &&
+          as_Register(rd)->is_compressed_valid()
+              ) { // [-32, 31]
+        c_andi(as_Register(rd), imm12);
+        return true;
+      }
+    } else if (funct3 == 0b001) {  // slli
+      uint32_t shamt = Assembler::extract(insn, 25, 20);
+      guarantee(shamt <= 0x3f, "Shamt is invalid");
+      if (rd == rs1 && as_Register(rd) != x0 && shamt != 0) {
+        c_slli(as_Register(rd), shamt);
+        return true;
+      }
+    } else if (funct3 == 0b101) {  // sr(l/a)i
+      if (rd == rs1 && as_Register(rd)->is_compressed_valid()) {
+        uint32_t shamt = Assembler::extract(insn, 25, 20);
+        guarantee(shamt <= 0x3f, "Shamt is invalid");
+        if (shamt != 0) {
+          uint32_t funct6 = Assembler::extract(insn, 31, 26);
+          if (funct6 == 0b000000) {  // srli
+            c_srli(as_Register(rd), shamt);
+            return true;
+          } else if (funct6 == 0b010000) {  // srai
+            c_srai(as_Register(rd), shamt);
+            return true;
+          } else {
+            ShouldNotReachHere();
+          }
+        }
+      }
+    }
+  } else if (opcode == 0b0110011 || opcode == 0b0111011) {  // sub/add/subw/addw
+    uint32_t rs2 = Assembler::extract(insn, 24, 20);
+    uint32_t rs1 = Assembler::extract(insn, 19, 15);
+    uint32_t rd = Assembler::extract(insn, 11, 7);
+    uint32_t funct3 = Assembler::extract(insn, 14, 12);
+    uint32_t funct7 = Assembler::extract(insn, 31, 25);
+    if (funct3 == 0b000 && funct7 == 0b0000000) {  // add/addw
+      Register src = noreg;
+      if (opcode == 0b0110011) {  // add
+        if (as_Register(rs1) != x0 &&
+            as_Register(rs2) != x0 &&
+            ((src = as_Register(rs1), rs2 == rd) || (src = as_Register(rs2), rs1 == rd))
+                ) {
+          c_add(as_Register(rd), src);
+          return true;
+        }
+      } else if (opcode == 0b0111011) {  // addw
+        if (as_Register(rs1)->is_compressed_valid() &&
+            as_Register(rs2)->is_compressed_valid() &&
+            ((src = as_Register(rs1), rs2 == rd) || (src = as_Register(rs2), rs1 == rd))
+                ) {
+          c_addw(as_Register(rd), src);
+          return true;
+        }
+      } else {
+        ShouldNotReachHere();
+      }
+    } else if (funct3 == 0b000 && funct7 == 0b0100000) {  // sub/subw
+      if (rs1 == rd &&
+          as_Register(rd)->is_compressed_valid() &&
+          as_Register(rs2)->is_compressed_valid()
+              ) {
+        if (opcode == 0b0110011) {  // sub
+          c_sub(as_Register(rd), as_Register(rs2));
+        } else if (opcode == 0b0111011) {  // subw
+          c_subw(as_Register(rd), as_Register(rs2));
+        } else {
+          ShouldNotReachHere();
+        }
+        return true;
+      }
+    } else if (funct7 == 0b0000000 &&
+               (funct3 == 0b100 || funct3 == 0b110 || funct3 == 0b111)  // xor/or/and
+            ) {
+      Register src = noreg;
+      if (as_Register(rs1)->is_compressed_valid() &&
+          as_Register(rs2)->is_compressed_valid() &&
+          ((src = as_Register(rs1), rs2 == rd) || (src = as_Register(rs2), rs1 == rd))
+              ) {
+        if (funct3 == 0b100) {  // xor
+          c_xor(as_Register(rd), src);
+        } else if (funct3 == 0b110) {  // or
+          c_or(as_Register(rd), src);
+        } else if (funct3 == 0b111) {  // and
+          c_and(as_Register(rd), src);
+        } else {
+          ShouldNotReachHere();
+        }
+        return true;
+      }
+    }
+  } else if (opcode == 0b0011011) {
+    uint32_t funct3 = Assembler::extract(insn, 14, 12);
+    uint32_t rs1 = Assembler::extract(insn, 19, 15);
+    uint32_t rd = Assembler::extract(insn, 11, 7);
+    if (funct3 == 0b000) {  // addiw
+      int32_t imm12 = Assembler::sextract(insn, 31, 20);
+      guarantee(is_imm_in_range(imm12, 12, 0), "must be");
+      if (rd == rs1 && as_Register(rd) != x0 && is_imm_in_range(imm12, 6, 0)) { // [-32, 31]
+        c_addiw(as_Register(rd), imm12);
+        return true;
+      }
+    }
+  } else if (opcode == 0b0000011) {  // ld family
+    if (emit_compressed_ld_st(insn, true)) {
+      return true;
+    }
+  } else if (opcode == 0b0100011) {  // sd family
+    if (emit_compressed_ld_st(insn, false)) {
+      return true;
+    }
+  } else if (opcode == 0b0000111) {  // fld family
+    if (emit_compressed_fld_fst(insn, true)) {
+      return true;
+    }
+  } else if (opcode == 0b0100111) {  // fsd family
+    if (emit_compressed_fld_fst(insn, false)) {
+      return true;
+    }
+  } else if (opcode == 0b0110111) {  // lui
+    // lui's imm20 has already left shifted by 12.
+    int32_t imm20 = Assembler::sextract(insn, 31, 12) << 12;
+    uint32_t rd = Assembler::extract(insn, 11, 7);
+    Register rd_reg = as_Register(rd);
+    if (is_imm_in_range(imm20, 18, 0) && rd_reg != x0 && rd_reg != x2 && imm20 != 0) {
+      c_lui(rd_reg, imm20);
+      return true;
+    }
+  } else if (opcode == 0b1110011) {
+    if (Assembler::extract(insn, 14, 12) == 0x0 &&
+        Assembler::extract(insn, 31, 20) == 0x1) {  // ebreak
+      c_ebreak();
+      return true;
+    }
+  } else if (opcode == 0b1100111) {  // jalr/jr
+    uint32_t rs1 = Assembler::extract(insn, 19, 15);
+    uint32_t rd = Assembler::extract(insn, 11, 7);
+    int32_t imm12 = Assembler::sextract(insn, 31, 20);
+    if (imm12 == 0 && as_Register(rs1) != x0) {
+      if (as_Register(rd) == x1) {
+        c_jalr(as_Register(rs1));
+        return true;
+      } else if (as_Register(rd) == x0) {
+        c_jr(as_Register(rs1));
+        return true;
+      }
+    }
+  } else if (opcode == 0b1101111) {  // j
+    assert(NativeInstruction::is_jal_at((address)&insn), "sanity");
+    uint32_t rd = Assembler::extract(insn, 11, 7);
+    long offset = get_offset_of_jal(insn);
+    // TODO: Removing the 'offset != 0' check needs us to fix lots of '__ j''s to '__ j_nc' manually everywhere.
+    if (offset != 0 && is_imm_in_range(offset, 11, 1) && as_Register(rd) == x0) {
+      c_j(offset);
+      return true;
+    }
+  } else if (opcode == 0b1100011) {  // beqz/bnez
+    uint32_t funct3 = Assembler::extract(insn, 14, 12);
+    if (funct3 == 0b000 || funct3 == 0b001) {  // beqz/bnez
+      uint32_t rs2 = Assembler::extract(insn, 24, 20);
+      uint32_t rs1 = Assembler::extract(insn, 19, 15);
+      long offset = get_offset_of_conditional_branch(insn);
+      // TODO: Removing the 'offset != 0' check needs us to fix lots of '__beqz / __benz''s to '__beqz_nc / __bnez_nc' everywhere.
+      if (offset != 0 &&
+          is_imm_in_range(offset, 8, 1) &&
+          as_Register(rs2) == x0 &&
+          as_Register(rs1)->is_compressed_valid()
+              ) {
+        if (funct3 == 0b000) {
+          c_beqz(as_Register(rs1), offset);
+        } else if (funct3 == 0b001) {
+          c_bnez(as_Register(rs1), offset);
+        } else {
+          ShouldNotReachHere();
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void Assembler::emit_may_compress(unsigned insn) {
+  if (!emit_compressed_instruction(insn)) {
+    emit((jint)insn);
+  }
 }
 
 void Assembler::add(Register Rd, Register Rn, int64_t increment, Register temp) {
@@ -80,6 +448,11 @@ void Assembler::subw(Register Rd, Register Rn, int64_t decrement, Register temp)
 }
 
 void Assembler::li(Register Rd, int64_t imm) {
+  if (UseCExt && is_imm_in_range(imm, 6, 0) && Rd != x0) {
+    c_li(Rd, imm);
+    return;
+  }
+
   // int64_t is in range 0x8000 0000 0000 0000 ~ 0x7fff ffff ffff ffff
   int shift = 12;
   int64_t upper = imm, lower = imm;
@@ -124,18 +497,18 @@ void Assembler::li64(Register Rd, int64_t imm) {
    lo = (lo << 52) >> 52;
    up -= lo;
    up = (int32_t)up;
-   lui(Rd, up);
-   addi(Rd, Rd, lo);
+   lui_nc(Rd, up);
+   addi_nc(Rd, Rd, lo);
 
    // Load the rest 32 bits.
    slli(Rd, Rd, 12);
-   addi(Rd, Rd, (int32_t)lower >> 20);
+   addi_nc(Rd, Rd, (int32_t)lower >> 20);
    slli(Rd, Rd, 12);
    lower = ((int32_t)imm << 12) >> 20;
-   addi(Rd, Rd, lower);
+   addi_nc(Rd, Rd, lower);
    slli(Rd, Rd, 8);
    lower = imm & 0xff;
-   addi(Rd, Rd, lower);
+   addi_nc(Rd, Rd, lower);
 }
 
 void Assembler::li32(Register Rd, int32_t imm) {
@@ -145,40 +518,67 @@ void Assembler::li32(Register Rd, int32_t imm) {
   upper -= lower;
   upper = (int32_t)upper;
   // lui Rd, imm[31:12] + imm[11]
-  lui(Rd, upper);
+  lui_nc(Rd, upper);
   // use addiw to distinguish li32 to li64
-  addiw(Rd, Rd, lower);
+  addiw_nc(Rd, Rd, lower);
 }
 
-#define INSN(NAME, REGISTER)                                       \
+#define COMPRESSED    true
+#define NORMAL        false
+
+#define INSN(NAME, REGISTER, compressed)                           \
   void Assembler::NAME(const address &dest, Register temp) {       \
     assert_cond(dest != NULL);                                     \
     int64_t distance = dest - pc();                                \
     if (is_imm_in_range(distance, 20, 1)) {                        \
-      jal(REGISTER, distance);                                     \
+      if (compressed) {                                            \
+        jal(REGISTER, distance);                                   \
+      } else {                                                     \
+        jal_nc(REGISTER, distance);                                \
+      }                                                            \
     } else {                                                       \
       assert(temp != noreg, "temp must not be empty register!");   \
       int32_t offset = 0;                                          \
       movptr_with_offset(temp, dest, offset);                      \
-      jalr(REGISTER, temp, offset);                                \
+      if (compressed) {                                            \
+        jalr(REGISTER, temp, offset);                              \
+      } else {                                                     \
+        jalr_nc(REGISTER, temp, offset);                           \
+      }                                                            \
     }                                                              \
   }                                                                \
   void Assembler::NAME(Label &l, Register temp) {                  \
-    jal(REGISTER, l, temp);                                        \
+    if (compressed) {                                              \
+      jal(REGISTER, l, temp);                                      \
+    } else {                                                       \
+      jal_nc(REGISTER, l, temp);                                   \
+    }                                                              \
   }                                                                \
 
-  INSN(j,   x0);
-  INSN(jal, x1);
+  INSN(j,    x0, COMPRESSED);
+  INSN(jal,  x1, COMPRESSED);
+
+  // C-Ext: uncompressed version
+  INSN(j_nc,   x0, NORMAL);
+  INSN(jal_nc, x1, NORMAL);
 
 #undef INSN
 
-#define INSN(NAME, REGISTER)                                       \
+#define INSN(NAME, REGISTER, compressed)                           \
   void Assembler::NAME(Register Rs) {                              \
-    jalr(REGISTER, Rs, 0);                                         \
+  if (compressed) {                                                \
+      jalr(REGISTER, Rs, 0);                                       \
+    } else {                                                       \
+      jalr_nc(REGISTER, Rs, 0);                                    \
+    }                                                              \
   }
 
-  INSN(jr,   x0);
-  INSN(jalr, x1);
+  INSN(jr,      x0, COMPRESSED);
+  INSN(jalr,    x1, COMPRESSED);
+
+  // C-Ext: uncompressed version
+  INSN(jr_nc,   x0, NORMAL);
+  INSN(jalr_nc, x1, NORMAL);
 
 #undef INSN
 
@@ -206,7 +606,7 @@ void Assembler::ret() {
 
 #undef INSN
 
-#define INSN(NAME, REGISTER)                                   \
+#define INSN(NAME, REGISTER, compressed)                       \
   void Assembler::NAME(const Address &adr, Register temp) {    \
     switch(adr.getMode()) {                                    \
       case Address::literal: {                                 \
@@ -217,7 +617,11 @@ void Assembler::ret() {
       case Address::base_plus_offset:{                         \
         int32_t offset = 0;                                    \
         baseOffset(temp, adr, offset);                         \
-        jalr(REGISTER, temp, offset);                          \
+        if (compressed) {                                      \
+          jalr(REGISTER, temp, offset);                        \
+        } else {                                               \
+          jalr_nc(REGISTER, temp, offset);                     \
+        }                                                      \
         break;                                                 \
       }                                                        \
       default:                                                 \
@@ -225,19 +629,26 @@ void Assembler::ret() {
     }                                                          \
   }
 
-  INSN(j,    x0);
-  INSN(jal,  x1);
-  INSN(call, x1);
-  INSN(tail, x0);
+  INSN(j,    x0, COMPRESSED);
+  INSN(jal,  x1, COMPRESSED);
+  INSN(call, x1, COMPRESSED);
+  INSN(tail, x0, COMPRESSED);
+
+  // C-Ext: uncompressed version
+  INSN(j_nc,   x0, NORMAL);
+  INSN(jal_nc, x1, NORMAL);
 
 #undef INSN
+
+#undef NORMAL
+#undef COMPRESSED
 
 void Assembler::wrap_label(Register r1, Register r2, Label &L, compare_and_branch_insn insn,
                            compare_and_branch_label_insn neg_insn, bool is_far) {
   if (is_far) {
     Label done;
     (this->*neg_insn)(r1, r2, done, /* is_far */ false);
-    j(L);
+    j_nc(L);
     bind(done);
   } else {
     if (L.is_bound()) {
@@ -267,7 +678,25 @@ void Assembler::wrap_label(Register Rt, Label &L, jal_jalr_insn insn) {
   }
 }
 
-void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
+void Assembler::wrap_label(Label &L, c_j_insn insn) {
+  if (L.is_bound()) {
+    (this->*insn)(target(L));
+  } else {
+    L.add_patch_at(code(), locator());
+    (this->*insn)(pc());
+  }
+}
+
+void Assembler::wrap_label(Label &L, Register r, c_compare_and_branch_insn insn) {
+  if (L.is_bound()) {
+    (this->*insn)(r, target(L));
+  } else {
+    L.add_patch_at(code(), locator());
+    (this->*insn)(r, pc());
+  }
+}
+
+void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset, bool compressed) {
   uintptr_t imm64 = (uintptr_t)addr;
 #ifndef PRODUCT
   {
@@ -283,26 +712,39 @@ void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
   lower = (lower << 52) >> 52;
   upper -= lower;
   upper = (int32_t)upper;
-  lui(Rd, upper);
-  addi(Rd, Rd, lower);
+  if (compressed) {
+    lui(Rd, upper);
+    addi(Rd, Rd, lower);
+  } else {
+    lui_nc(Rd, upper);
+    addi_nc(Rd, Rd, lower);
+  }
 
   // Load the rest 16 bits.
   slli(Rd, Rd, 11);
-  addi(Rd, Rd, (imm64 >> 5) & 0x7ff);
+  if (compressed) {
+    addi(Rd, Rd, (imm64 >> 5) & 0x7ff);
+  } else {
+    addi_nc(Rd, Rd, (imm64 >> 5) & 0x7ff);
+  }
   slli(Rd, Rd, 5);
 
   // Here, remove the addi instruct and return the offset directly. This offset will be used by following jalr/ld.
   offset = imm64 & 0x1f;
 }
 
-void Assembler::movptr(Register Rd, uintptr_t imm64) {
-  movptr(Rd, (address)imm64);
+void Assembler::movptr(Register Rd, uintptr_t imm64, bool compressed) {
+  movptr(Rd, (address)imm64, compressed);
 }
 
-void Assembler::movptr(Register Rd, address addr) {
+void Assembler::movptr(Register Rd, address addr, bool compressed) {
   int offset = 0;
-  movptr_with_offset(Rd, addr, offset);
-  addi(Rd, Rd, offset);
+  movptr_with_offset(Rd, addr, offset, compressed);
+  if (compressed) {
+    addi(Rd, Rd, offset);
+  } else {
+    addi_nc(Rd, Rd, offset);
+  }
 }
 
 void Assembler::ifence() {
@@ -312,12 +754,12 @@ void Assembler::ifence() {
   }
 }
 
-#define INSN(NAME, NEG_INSN)                                                         \
-  void Assembler::NAME(Register Rs, Register Rt, const address &dest) {              \
-    NEG_INSN(Rt, Rs, dest);                                                          \
-  }                                                                                  \
-  void Assembler::NAME(Register Rs, Register Rt, Label &l, bool is_far) {            \
-    NEG_INSN(Rt, Rs, l, is_far);                                                     \
+#define INSN(NAME, NEG_INSN)                                                               \
+  void Assembler::NAME(Register Rs, Register Rt, const address &dest) {                    \
+    NEG_INSN(Rt, Rs, dest);                                                                \
+  }                                                                                        \
+  void Assembler::NAME(Register Rs, Register Rt, Label &l, bool is_far) {                  \
+    NEG_INSN(Rt, Rs, l, is_far);                                                           \
   }
 
   INSN(bgt,  blt);

--- a/src/hotspot/cpu/riscv64/assembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/assembler_riscv64.cpp
@@ -84,17 +84,16 @@ bool Assembler::emit_compressed_ld_st(unsigned int insn, bool ld) {
   Register rs1 = as_Register(rs1_bits);
   Register rd_rs2 = as_Register(rd_rs2_bits);
   if (funct3 == 0b011) {  // ld/sd
-    // ld/sd(Rd, Address(sp, 8n)), which n >= 0
     if (is_cldsdsp(rs1, rd_rs2, imm12, ld)) {
+      // ld/sd(Rd, Address(sp, 8n)), which n >= 0
       if (ld) {
         c_ldsp(rd_rs2, imm12);
       } else {
         c_sdsp(rd_rs2, imm12);
       }
       return true;
-    } else
-    // ld/sd(compressed_Rd, Address(compressed_Rs, 8n)), which n >= 0
-    if (is_cldsd(rs1, rd_rs2, imm12)) {
+    } else if (is_cldsd(rs1, rd_rs2, imm12)) {
+      // ld/sd(compressed_Rd, Address(compressed_Rs, 8n)), which n >= 0
       if (ld) {
         c_ld(rd_rs2, rs1, imm12);
       } else {
@@ -103,17 +102,16 @@ bool Assembler::emit_compressed_ld_st(unsigned int insn, bool ld) {
       return true;
     }
   } else if (funct3 == 0b010) {  // lw
-    // lw/sw(Rd, Address(sp, 4n)), which n >= 0
     if (is_clwswsp(rs1, rd_rs2, imm12, ld)) {
+      // lw/sw(Rd, Address(sp, 4n)), which n >= 0
       if (ld) {
         c_lwsp(rd_rs2, imm12);
       } else {
         c_swsp(rd_rs2, imm12);
       }
       return true;
-    } else
-    // lw/sw(compressed_Rd, Address(compressed_Rs1, 4n)), which n >= 0
-    if (is_clwsw(rs1, rd_rs2, imm12)) {
+    } else if (is_clwsw(rs1, rd_rs2, imm12)) {
+      // lw/sw(compressed_Rd, Address(compressed_Rs1, 4n)), which n >= 0
       if (ld) {
         c_lw(rd_rs2, rs1, imm12);
       } else {
@@ -143,21 +141,18 @@ bool Assembler::emit_compressed_fld_fst(unsigned int insn, bool ld) {
     // fld/fsd(Rd, Address(sp, 8n)), which n >= 0
     if (as_Register(rs1) == sp &&
         is_unsigned_imm_in_range(imm12, 9, 0) &&
-        (intx(imm12) & 0b111) == 0x0
-        ) {
+        (intx(imm12) & 0b111) == 0x0) {
       if (ld) {
         c_fldsp(as_FloatRegister(rd_rs2), imm12);
       } else {
         c_fsdsp(as_FloatRegister(rd_rs2), imm12);
       }
       return true;
-    } else
-    // ld/sd(compressed_Rd, Address(compressed_Rs, 8n)), which n >= 0
-    if (as_Register(rs1)->is_compressed_valid() &&
+    } else if (as_Register(rs1)->is_compressed_valid() &&
         as_FloatRegister(rd_rs2)->is_compressed_valid() &&
         is_unsigned_imm_in_range(imm12, 8, 0) &&
-        (intx(imm12) & 0b111) == 0x0
-        ) {
+        (intx(imm12) & 0b111) == 0x0) {
+      // ld/sd(compressed_Rd, Address(compressed_Rs, 8n)), which n >= 0
       if (ld) {
         c_fld(as_FloatRegister(rd_rs2), as_Register(rs1), imm12);
       } else {

--- a/src/hotspot/cpu/riscv64/c1_CodeStubs_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_CodeStubs_riscv64.cpp
@@ -44,7 +44,7 @@ void C1SafepointPollStub::emit_code(LIR_Assembler* ce)
   __ bind(_entry);
   InternalAddress safepoint_pc(__ pc() - __ offset() + safepoint_offset());
   __ code_section()->relocate(__ pc(), safepoint_pc.rspec());
-  __ la(t0, safepoint_pc.target());
+  __ la(t0, safepoint_pc.target(), false);
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
 
   assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
@@ -108,7 +108,7 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce)
   }
   int32_t off = 0;
   __ la_patchable(lr, RuntimeAddress(Runtime1::entry_for(stub_id)), off);
-  __ jalr(lr, lr, off);
+  __ jalr_nc(lr, lr, off);
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
   debug_only(__ should_not_reach_here());
@@ -257,7 +257,7 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce)
   __ far_jump(RuntimeAddress(Runtime1::entry_for(exit_id)));
 }
 
-int PatchingStub::_patch_info_offset = -NativeGeneralJump::instruction_size;
+int PatchingStub::_patch_info_offset = -NativeGeneralJump::get_instruction_size();
 
 void PatchingStub::align_patch_site(MacroAssembler* masm) {}
 

--- a/src/hotspot/cpu/riscv64/c1_LIRAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_LIRAssembler_riscv64.cpp
@@ -1393,7 +1393,7 @@ void LIR_Assembler::throw_op(LIR_Opr exceptionPC, LIR_Opr exceptionOop, CodeEmit
   InternalAddress pc_for_athrow(__ pc());
   int32_t off = 0;
   __ la_patchable(exceptionPC->as_register(), pc_for_athrow, off);
-  __ addi(exceptionPC->as_register(), exceptionPC->as_register(), off);
+  __ addi_nc(exceptionPC->as_register(), exceptionPC->as_register(), off);
   add_call_info(pc_for_athrow_offset, info); // for exception handler
 
   __ verify_not_null_oop(x10);
@@ -1806,7 +1806,7 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest, const LIR_OprList* arg
   } else {
     int32_t offset = 0;
     __ la_patchable(t0, RuntimeAddress(dest), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_nc(x1, t0, offset);
   }
 
   if (info != NULL) {

--- a/src/hotspot/cpu/riscv64/c1_MacroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_MacroAssembler_riscv64.cpp
@@ -348,7 +348,7 @@ void C1_MacroAssembler::verified_entry() {
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
 
-  nop();
+  nop_nc();
 }
 
 void C1_MacroAssembler::load_parameter(int offset_in_words, Register reg) {

--- a/src/hotspot/cpu/riscv64/c1_Runtime1_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_Runtime1_riscv64.cpp
@@ -69,7 +69,7 @@ int StubAssembler::call_RT(Register oop_result, Register metadata_result, addres
   // do the call
   int32_t off = 0;
   la_patchable(t0, RuntimeAddress(entry), off);
-  jalr(x1, t0, off);
+  jalr_nc(x1, t0, off);
   bind(retaddr);
   int call_offset = offset();
   // verify callee-saved register
@@ -565,7 +565,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   // do the call
   int32_t off = 0;
   __ la_patchable(t0, RuntimeAddress(target), off);
-  __ jalr(x1, t0, off);
+  __ jalr_nc(x1, t0, off);
   __ bind(retaddr);
   OopMapSet* oop_maps = new OopMapSet();
   assert_cond(oop_maps != NULL);

--- a/src/hotspot/cpu/riscv64/c2_MacroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c2_MacroAssembler_riscv64.cpp
@@ -1196,21 +1196,21 @@ typedef void (MacroAssembler::*float_conditional_branch_insn)(FloatRegister op1,
 static conditional_branch_insn conditional_branches[] =
 {
   /* SHORT branches */
-  (conditional_branch_insn)&Assembler::beq,
+  (conditional_branch_insn)&Assembler::beq_nc,
   (conditional_branch_insn)&Assembler::bgt,
   NULL, // BoolTest::overflow
   (conditional_branch_insn)&Assembler::blt,
-  (conditional_branch_insn)&Assembler::bne,
+  (conditional_branch_insn)&Assembler::bne_nc,
   (conditional_branch_insn)&Assembler::ble,
   NULL, // BoolTest::no_overflow
   (conditional_branch_insn)&Assembler::bge,
 
   /* UNSIGNED branches */
-  (conditional_branch_insn)&Assembler::beq,
+  (conditional_branch_insn)&Assembler::beq_nc,
   (conditional_branch_insn)&Assembler::bgtu,
   NULL,
   (conditional_branch_insn)&Assembler::bltu,
-  (conditional_branch_insn)&Assembler::bne,
+  (conditional_branch_insn)&Assembler::bne_nc,
   (conditional_branch_insn)&Assembler::bleu,
   NULL,
   (conditional_branch_insn)&Assembler::bgeu
@@ -1259,11 +1259,11 @@ void C2_MacroAssembler::enc_cmpUEqNeLeGt_imm0_branch(int cmpFlag, Register op1, 
   switch (cmpFlag) {
     case BoolTest::eq:
     case BoolTest::le:
-      beqz(op1, L, is_far);
+      beqz_nc(op1, L, is_far);
       break;
     case BoolTest::ne:
     case BoolTest::gt:
-      bnez(op1, L, is_far);
+      bnez_nc(op1, L, is_far);
       break;
     default:
       ShouldNotReachHere();
@@ -1273,10 +1273,10 @@ void C2_MacroAssembler::enc_cmpUEqNeLeGt_imm0_branch(int cmpFlag, Register op1, 
 void C2_MacroAssembler::enc_cmpEqNe_imm0_branch(int cmpFlag, Register op1, Label& L, bool is_far) {
   switch (cmpFlag) {
     case BoolTest::eq:
-      beqz(op1, L, is_far);
+      beqz_nc(op1, L, is_far);
       break;
     case BoolTest::ne:
-      bnez(op1, L, is_far);
+      bnez_nc(op1, L, is_far);
       break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/cpu/riscv64/c2_MacroAssembler_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/c2_MacroAssembler_riscv64.hpp
@@ -82,6 +82,16 @@
   static const int double_branch_mask = 1 << bool_test_bits;
 
   // cmp
+  // C-Ext: these cmp functions remain uncompressed in C2 MachNodes' emission -
+  //   as the reason described in MachEpilogNode::emit() in PhaseOutput::scratch_emit_size()
+  //   it simulates a node's size, but for MachBranchNodes it emits a fake Label just
+  //   near the node itself - the offset is so small that in scratch emission phase it always
+  //   get compressed in our implicit compression phase - but in real world the Label may be
+  //   anywhere so it may not be compressed, so here is the mismatch: it runs shorten_branches();
+  //   but with C-Ext we may need a further, say, shorten_compressed_branches() or something.
+  //   After researching we find performance will not have much enhancement even if compressing
+  //   them and the cost is a bit big to support MachBranchNodes' compression.
+  //   So as a solution, we can simply disable the compression of MachBranchNodes.
   void cmp_branch(int cmpFlag,
                   Register op1, Register op2,
                   Label& label, bool is_far = false);

--- a/src/hotspot/cpu/riscv64/c2_globals_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/c2_globals_riscv64.hpp
@@ -49,7 +49,7 @@ define_pd_global(intx, FLOATPRESSURE,                32);
 define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
 define_pd_global(intx, INTPRESSURE,                  24);
-define_pd_global(intx, InteriorEntryAlignment,       16);
+define_pd_global(intx, InteriorEntryAlignment,       4);
 define_pd_global(intx, NewSizeThreadIncrease, ScaleForWordSize(4*K));
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);

--- a/src/hotspot/cpu/riscv64/c2_safepointPollStubTable_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c2_safepointPollStubTable_riscv64.cpp
@@ -41,7 +41,7 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
   __ bind(entry->_stub_label);
   InternalAddress safepoint_pc(masm.pc() - masm.offset() + entry->_safepoint_offset);
   masm.code_section()->relocate(masm.pc(), safepoint_pc.rspec());
-  __ la(t0, safepoint_pc.target());
+  __ la(t0, safepoint_pc.target(), false);
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
   __ far_jump(callback_addr);
 }

--- a/src/hotspot/cpu/riscv64/compiledIC_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/compiledIC_riscv64.cpp
@@ -69,8 +69,12 @@ address CompiledStaticCall::emit_to_interp_stub(CodeBuffer &cbuf, address mark) 
 #undef __
 
 int CompiledStaticCall::to_interp_stub_size() {
-  // fence_i + fence* + (lui, addi, slli, addi, slli, addi) + (lui, addi, slli, addi, slli) + jalr
-  return NativeFenceI::instruction_size() + 12 * NativeInstruction::instruction_size;
+  // fence_i + fence* + (lui, addi, slli(C), addi, slli(C), addi) + (lui, addi, slli(C), addi, slli(C)) + jalr
+  return NativeFenceI::instruction_size() +
+         (!UseCExt ?
+           12 * NativeInstruction::instruction_size :
+           8 * NativeInstruction::instruction_size + 4 * NativeInstruction::compressed_instruction_size
+         );
 }
 
 int CompiledStaticCall::to_trampoline_stub_size() {

--- a/src/hotspot/cpu/riscv64/gc/shared/barrierSetNMethod_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/gc/shared/barrierSetNMethod_riscv64.cpp
@@ -36,11 +36,21 @@
 #include "utilities/debug.hpp"
 
 class NativeNMethodBarrier: public NativeInstruction {
+public:
+  enum {
+    total_normal_guard_offset     = 12 * instruction_size,
+    total_compressed_guard_offset = 10 * instruction_size + 2 * compressed_instruction_size,
+
+    total_normal_size             = total_normal_guard_offset + 4,
+    total_compressed_size         = total_compressed_guard_offset + 4,
+  };
+
+private:
   address instruction_address() const { return addr_at(0); }
 
   int *guard_addr() {
-    /* auipc + lwu + fence + lwu + beq + lui + addi + slli + addi + slli + jalr + j */
-    return reinterpret_cast<int*>(instruction_address() + 12 * 4);
+    /* auipc + lwu + fence + lwu + beq + lui + addi + (C)slli + addi + (C)slli + jalr + j */
+    return reinterpret_cast<int*>(instruction_address() + guard_offset());
   }
 
 public:
@@ -53,28 +63,55 @@ public:
   }
 
   void verify() const;
+
+  static int guard_offset() {
+    return UseCExt ? total_compressed_guard_offset : total_normal_guard_offset;
+  }
 };
+
+int nmethod_barrier_guard_offset() {
+  return NativeNMethodBarrier::guard_offset();
+}
 
 // Store the instruction bitmask, bits and name for checking the barrier.
 struct CheckInsn {
   uint32_t mask;
   uint32_t bits;
   const char *name;
+  int instruction_size;
 };
 
 static const struct CheckInsn barrierInsn[] = {
-  { 0x00000fff, 0x00000297, "auipc  t0, 0           "},
-  { 0x000fffff, 0x0002e283, "lwu    t0, 48(t0)      "},
-  { 0xffffffff, 0x0aa0000f, "fence  ir, ir          "},
-  { 0x000fffff, 0x000be303, "lwu    t1, 112(xthread)"},
-  { 0x01fff07f, 0x00628063, "beq    t0, t1, skip    "},
-  { 0x00000fff, 0x000002b7, "lui    t0, imm0        "},
-  { 0x000fffff, 0x00028293, "addi   t0, t0, imm1    "},
-  { 0xffffffff, 0x00b29293, "slli   t0, t0, 11      "},
-  { 0x000fffff, 0x00028293, "addi   t0, t0, imm2    "},
-  { 0xffffffff, 0x00529293, "slli   t0, t0, 5       "},
-  { 0x000fffff, 0x000280e7, "jalr   lr, imm3(t0)    "},
-  { 0x00000fff, 0x0000006f, "j      skip            "}
+  { 0x00000fff, 0x00000297, "auipc  t0, 0           ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x0002e283, "lwu    t0, 48(t0)      ", NativeInstruction::instruction_size},
+  { 0xffffffff, 0x0aa0000f, "fence  ir, ir          ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x000be303, "lwu    t1, 36(xthread) ", NativeInstruction::instruction_size},
+  { 0x01fff07f, 0x00628063, "beq    t0, t1, skip    ", NativeInstruction::instruction_size},
+  { 0x00000fff, 0x000002b7, "lui    t0, imm0        ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x00028293, "addi   t0, t0, imm1    ", NativeInstruction::instruction_size},
+  { 0xffffffff, 0x00b29293, "slli   t0, t0, 11      ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x00028293, "addi   t0, t0, imm2    ", NativeInstruction::instruction_size},
+  { 0xffffffff, 0x00529293, "slli   t0, t0, 5       ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x000280e7, "jalr   lr, imm3(t0)    ", NativeInstruction::instruction_size},
+  { 0x00000fff, 0x0000006f, "j      skip            ", NativeInstruction::instruction_size}
+  /* guard: */
+  /* 32bit nmethod guard value */
+  /* skip: */
+};
+
+static const struct CheckInsn barrierCInsn[] = {
+  { 0x00000fff, 0x00000297, "auipc  t0, 0           ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x0002e283, "lwu    t0, 44(t0)      ", NativeInstruction::instruction_size},
+  { 0xffffffff, 0x0aa0000f, "fence  ir, ir          ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x000be303, "lwu    t1, 36(xthread) ", NativeInstruction::instruction_size},
+  { 0x01fff07f, 0x00628063, "beq    t0, t1, skip    ", NativeInstruction::instruction_size},
+  { 0x00000fff, 0x000002b7, "lui    t0, imm0        ", NativeInstruction::instruction_size},
+  { 0x000fffff, 0x00028293, "addi   t0, t0, imm1    ", NativeInstruction::instruction_size},
+  { 0x00000fff, 0x02ae,     "c.slli t0, t0, 11      ", NativeInstruction::compressed_instruction_size},
+  { 0x000fffff, 0x00028293, "addi   t0, t0, imm2    ", NativeInstruction::instruction_size},
+  { 0x0000ffff, 0x0296,     "c.slli t0, t0, 5       ", NativeInstruction::compressed_instruction_size},
+  { 0x000fffff, 0x000280e7, "jalr   lr, imm3(t0)    ", NativeInstruction::instruction_size},
+  { 0x00000fff, 0x0000006f, "j      skip            ", NativeInstruction::instruction_size}
   /* guard: */
   /* 32bit nmethod guard value */
   /* skip: */
@@ -85,13 +122,22 @@ static const struct CheckInsn barrierInsn[] = {
 // register numbers and immediate values in the encoding.
 void NativeNMethodBarrier::verify() const {
   intptr_t addr = (intptr_t) instruction_address();
-  for(unsigned int i = 0; i < sizeof(barrierInsn)/sizeof(struct CheckInsn); i++ ) {
-    uint32_t inst = *((uint32_t*) addr);
-    if ((inst & barrierInsn[i].mask) != barrierInsn[i].bits) {
+  const struct CheckInsn *insns;
+  size_t size;
+  if (!UseCExt) {
+    insns = barrierInsn;
+    size = sizeof(barrierInsn) / sizeof(struct CheckInsn);
+  } else {
+    insns = barrierCInsn;
+    size = sizeof(barrierCInsn) / sizeof(struct CheckInsn);
+  }
+  for(unsigned int i = 0; i < size; i++ ) {
+    uint32_t inst = insns[i].instruction_size == NativeInstruction::compressed_instruction_size ? *((uint16_t*) addr) : *((uint32_t*) addr);
+    if ((inst & insns[i].mask) != insns[i].bits) {
       tty->print_cr("Addr: " INTPTR_FORMAT " Code: 0x%x", addr, inst);
-      fatal("not an %s instruction.", barrierInsn[i].name);
+      fatal("not an %s instruction.", insns[i].name);
     }
-    addr += 4;
+    addr += insns[i].instruction_size;
   }
 }
 
@@ -141,10 +187,15 @@ void BarrierSetNMethod::deoptimize(nmethod* nm, address* return_address_ptr) {
 
 // see BarrierSetAssembler::nmethod_entry_barrier
 // auipc + lwu + fence + lwu + beq + movptr_with_offset(5 instructions) + jalr + j + int32
-static const int entry_barrier_offset = -4 * 13;
+static const int entry_barrier_normal_offset = -NativeNMethodBarrier::total_normal_size;
+static const int entry_barrier_compressed_offset = -NativeNMethodBarrier::total_compressed_size;
+
+static const int entry_barrier_offset() {
+  return !UseCExt ? entry_barrier_normal_offset : entry_barrier_compressed_offset;
+}
 
 static NativeNMethodBarrier* native_nmethod_barrier(nmethod* nm) {
-  address barrier_address = nm->code_begin() + nm->frame_complete_offset() + entry_barrier_offset;
+  address barrier_address = nm->code_begin() + nm->frame_complete_offset() + entry_barrier_offset();
   NativeNMethodBarrier* barrier = reinterpret_cast<NativeNMethodBarrier*>(barrier_address);
   debug_only(barrier->verify());
   return barrier;

--- a/src/hotspot/cpu/riscv64/gc/z/zBarrierSetAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/gc/z/zBarrierSetAssembler_riscv64.cpp
@@ -338,7 +338,7 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
     ZSetupArguments setup_arguments(masm, stub);
     int32_t offset = 0;
     __ la_patchable(t0, stub->slow_path(), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_nc(x1, t0, offset);
   }
 
   // Stub exit

--- a/src/hotspot/cpu/riscv64/globals_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/globals_riscv64.hpp
@@ -38,7 +38,7 @@ define_pd_global(bool, TrapBasedNullChecks,      false);
 define_pd_global(bool, UncommonNullCast,         true);  // Uncommon-trap NULLs past to check cast
 
 define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
-define_pd_global(intx, CodeEntryAlignment,       64);
+define_pd_global(intx, CodeEntryAlignment,       16);
 define_pd_global(intx, OptoLoopAlignment,        16);
 define_pd_global(intx, InlineFrequencyCount,     100);
 
@@ -94,6 +94,7 @@ define_pd_global(intx, InlineSmallCode,          2500);
           "Extend i for r and o for w in the pred/succ flags of fence;" \
           "Extend fence.i to fence.i + fence.")                         \
   product(bool, UseVExt, false, "Use RVV instructions")                 \
+  product(bool, UseCExt, false, "Use RVC instructions")                 \
   product(bool, AvoidUnalignedAccesses, true,                           \
           "Avoid generating unaligned memory accesses")                 \
 

--- a/src/hotspot/cpu/riscv64/interp_masm_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/interp_masm_riscv64.cpp
@@ -185,7 +185,7 @@ void InterpreterMacroAssembler::get_unsigned_2_byte_index_at_bcp(Register reg, i
 void InterpreterMacroAssembler::get_dispatch() {
   int32_t offset = 0;
   la_patchable(xdispatch, ExternalAddress((address)Interpreter::dispatch_table()), offset);
-  addi(xdispatch, xdispatch, offset);
+  addi_nc(xdispatch, xdispatch, offset);
 }
 
 void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,

--- a/src/hotspot/cpu/riscv64/jniFastGetField_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/jniFastGetField_riscv64.cpp
@@ -76,7 +76,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   Label slow;
   int32_t offset = 0;
   __ la_patchable(rcounter_addr, SafepointSynchronize::safepoint_counter_addr(), offset);
-  __ addi(rcounter_addr, rcounter_addr, offset);
+  __ addi_nc(rcounter_addr, rcounter_addr, offset);
 
   Address safepoint_counter_addr(rcounter_addr, 0);
   __ lwu(rcounter, safepoint_counter_addr);
@@ -171,7 +171,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
     __ enter();
     int32_t tmp_offset = 0;
     __ la_patchable(t0, ExternalAddress(slow_case_addr), tmp_offset);
-    __ jalr(x1, t0, tmp_offset);
+    __ jalr_nc(x1, t0, tmp_offset);
     __ leave();
     __ ret();
   }

--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
@@ -226,10 +226,11 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
 void MacroAssembler::set_last_Java_frame(Register last_java_sp,
                                          Register last_java_fp,
                                          address  last_java_pc,
-                                         Register temp) {
+                                         Register temp,
+                                         bool compressed) {
   assert(last_java_pc != NULL, "must provide a valid PC");
 
-  la(temp, last_java_pc);
+  la(temp, last_java_pc, compressed);
   sd(temp, Address(xthread, JavaThread::frame_anchor_offset() + JavaFrameAnchor::last_Java_pc_offset()));
 
   set_last_Java_frame(last_java_sp, last_java_fp, noreg, temp);
@@ -244,7 +245,7 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
   } else {
     InstructionMark im(this);
     L.add_patch_at(code(), locator());
-    set_last_Java_frame(last_java_sp, last_java_fp, pc() /* Patched later */, temp);
+    set_last_Java_frame(last_java_sp, last_java_fp, pc() /* Patched later */, temp, false);
   }
 }
 
@@ -311,7 +312,7 @@ void MacroAssembler::call_VM_base(Register oop_result,
     beqz(t0, ok);
     int32_t offset = 0;
     la_patchable(t0, RuntimeAddress(StubRoutines::forward_exception_entry()), offset);
-    jalr(x0, t0, offset);
+    jalr_nc(x0, t0, offset);
     bind(ok);
   }
 
@@ -387,7 +388,7 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
   la_patchable(t1, ExternalAddress(StubRoutines::verify_oop_subroutine_entry_address()), offset);
-  ld(t1, Address(t1, offset));
+  ld_nc(t1, Address(t1, offset));
   jalr(t1);
 
   pop_reg(RegSet::of(lr, t0, t1, c_rarg0), sp);
@@ -426,7 +427,7 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
   la_patchable(t1, ExternalAddress(StubRoutines::verify_oop_subroutine_entry_address()), offset);
-  ld(t1, Address(t1, offset));
+  ld_nc(t1, Address(t1, offset));
   jalr(t1);
 
   pop_reg(RegSet::of(lr, t0, t1, c_rarg0), sp);
@@ -540,12 +541,21 @@ void MacroAssembler::resolve_jobject(Register value, Register thread, Register t
   bind(done);
 }
 
-void MacroAssembler::stop(const char* msg) {
+// C-Ext: we may need to disable the compression for some instructions
+//   in some Nodes during C2 code emission, to emit the same constant
+//   instruction size both in PhaseOutput::scratch_emit_size()
+//   and the final real code emission.
+//   See: MachEpilogNode::emit() for more details.
+void MacroAssembler::stop(const char* msg, bool compressed) {
   address ip = pc();
   pusha();
   if(msg != NULL && ip != NULL) {
     li(c_rarg0, (uintptr_t)(address)msg);
-    li(c_rarg1, (uintptr_t)(address)ip);
+    if (compressed) {
+      li(c_rarg1, (uintptr_t)(address)ip);
+    } else {
+      movptr(c_rarg1, (address)ip, false);
+    }
   } else {
     ShouldNotReachHere();
   }
@@ -576,8 +586,8 @@ void MacroAssembler::emit_static_call_stub() {
 
   // Jump to the entry point of the i2c stub.
   int32_t offset = 0;
-  movptr_with_offset(t0, 0, offset);
-  jalr(x0, t0, offset);
+  movptr_with_offset(t0, 0, offset, false);
+  jalr_nc(x0, t0, offset);
 }
 void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
@@ -666,6 +676,10 @@ void MacroAssembler::nop() {
   addi(x0, x0, 0);
 }
 
+void MacroAssembler::nop_nc() {
+  addi_nc(x0, x0, 0);
+}
+
 void MacroAssembler::mv(Register Rd, Register Rs) {
   if (Rd != Rs) {
     addi(Rd, Rs, 0);
@@ -744,13 +758,17 @@ void MacroAssembler::vfneg_v(VectorRegister vd, VectorRegister vs) {
   vfsgnjn_vv(vd, vs, vs);
 }
 
-void MacroAssembler::la(Register Rd, const address &dest) {
+void MacroAssembler::la(Register Rd, const address &dest, bool compressed) {
   int64_t offset = dest - pc();
   if (is_offset_in_range(offset, 32)) {
     auipc(Rd, (int32_t)offset + 0x800);  //0x800, Note:the 11th sign bit
-    addi(Rd, Rd, ((int64_t)offset << 52) >> 52);
+    if (compressed) {
+      addi(Rd, Rd, ((int64_t)offset << 52) >> 52);
+    } else {
+      addi_nc(Rd, Rd, ((int64_t)offset << 52) >> 52);
+    }
   } else {
-    movptr(Rd, dest);
+    movptr(Rd, dest, compressed);
   }
 }
 
@@ -764,7 +782,7 @@ void MacroAssembler::la(Register Rd, const Address &adr) {
       if (rtype == relocInfo::none) {
         li(Rd, (intptr_t)(adr.target()));
       } else {
-        movptr(Rd, adr.target());
+        movptr(Rd, adr.target(), false);
       }
       break;
     }
@@ -780,16 +798,16 @@ void MacroAssembler::la(Register Rd, const Address &adr) {
 }
 
 void MacroAssembler::la(Register Rd, Label &label) {
-  la(Rd, target(label));
+  la(Rd, target(label), false);
 }
 
-#define INSN(NAME)                                                                \
-  void MacroAssembler::NAME##z(Register Rs, const address &dest) {                \
-    NAME(Rs, zr, dest);                                                           \
-  }                                                                               \
-  void MacroAssembler::NAME##z(Register Rs, Label &l, bool is_far) {              \
-    NAME(Rs, zr, l, is_far);                                                      \
-  }                                                                               \
+#define INSN(NAME)                                                                    \
+  void MacroAssembler::NAME##z(Register Rs, const address &dest) {                    \
+    NAME(Rs, zr, dest);                                                               \
+  }                                                                                   \
+  void MacroAssembler::NAME##z(Register Rs, Label &l, bool is_far) {                  \
+    NAME(Rs, zr, l, is_far);                                                          \
+  }                                                                                   \
 
   INSN(beq);
   INSN(bne);
@@ -800,47 +818,61 @@ void MacroAssembler::la(Register Rd, Label &label) {
 
 #undef INSN
 
+#define INSN(NAME)                                                                    \
+  void MacroAssembler::NAME##z_nc(Register Rs, const address &dest) {                 \
+    NAME##_nc(Rs, zr, dest);                                                          \
+  }                                                                                   \
+  void MacroAssembler::NAME##z_nc(Register Rs, Label &l, bool is_far) {               \
+    NAME##_nc(Rs, zr, l, is_far);                                                     \
+  }                                                                                   \
+
+  INSN(beq);
+  INSN(bne);
+
+#undef INSN
+
 // Float compare branch instructions
 
-#define INSN(NAME, FLOATCMP, BRANCH)                                                                                   \
-  void MacroAssembler::float_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l, bool is_far, bool is_unordered) {  \
-    FLOATCMP##_s(t0, Rs1, Rs2);                                                                                        \
-    BRANCH(t0, l, is_far);                                                                                             \
-  }                                                                                                                    \
-  void MacroAssembler::double_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l, bool is_far, bool is_unordered) { \
-    FLOATCMP##_d(t0, Rs1, Rs2);                                                                                        \
-    BRANCH(t0, l, is_far);                                                                                             \
+#define INSN(NAME, FLOATCMP, BRANCH)                                                                                                     \
+  void MacroAssembler::float_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l, bool is_far, bool is_unordered) {                    \
+    FLOATCMP##_s(t0, Rs1, Rs2);                                                                                                          \
+    BRANCH(t0, l, is_far);                                                                                                               \
+  }                                                                                                                                      \
+  void MacroAssembler::double_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l, bool is_far, bool is_unordered) {                   \
+    FLOATCMP##_d(t0, Rs1, Rs2);                                                                                                          \
+    BRANCH(t0, l, is_far);                                                                                                               \
   }
 
-  INSN(beq, feq, bnez);
-  INSN(bne, feq, beqz);
+  INSN(beq, feq, bnez_nc);
+  INSN(bne, feq, beqz_nc);
+
 #undef INSN
 
 
-#define INSN(NAME, FLOATCMP1, FLOATCMP2)                                              \
-  void MacroAssembler::float_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,   \
-                                    bool is_far, bool is_unordered) {                 \
-    if(is_unordered) {                                                                \
-      /* jump if either source is NaN or condition is expected */                     \
-      FLOATCMP2##_s(t0, Rs2, Rs1);                                                    \
-      beqz(t0, l, is_far);                                                            \
-    } else {                                                                          \
-      /* jump if no NaN in source and condition is expected */                        \
-      FLOATCMP1##_s(t0, Rs1, Rs2);                                                    \
-      bnez(t0, l, is_far);                                                            \
-    }                                                                                 \
-  }                                                                                   \
-  void MacroAssembler::double_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,  \
-                                     bool is_far, bool is_unordered) {                \
-    if(is_unordered) {                                                                \
-      /* jump if either source is NaN or condition is expected */                     \
-      FLOATCMP2##_d(t0, Rs2, Rs1);                                                    \
-      beqz(t0, l, is_far);                                                            \
-    } else {                                                                          \
-      /* jump if no NaN in source and condition is expected */                        \
-      FLOATCMP1##_d(t0, Rs1, Rs2);                                                    \
-      bnez(t0, l, is_far);                                                            \
-    }                                                                                 \
+#define INSN(NAME, FLOATCMP1, FLOATCMP2)                                                 \
+  void MacroAssembler::float_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,      \
+                                    bool is_far, bool is_unordered) {                    \
+    if(is_unordered) {                                                                   \
+      /* jump if either source is NaN or condition is expected */                        \
+      FLOATCMP2##_s(t0, Rs2, Rs1);                                                       \
+      beqz_nc(t0, l, is_far);                                                            \
+    } else {                                                                             \
+      /* jump if no NaN in source and condition is expected */                           \
+      FLOATCMP1##_s(t0, Rs1, Rs2);                                                       \
+      bnez_nc(t0, l, is_far);                                                            \
+    }                                                                                    \
+  }                                                                                      \
+  void MacroAssembler::double_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,     \
+                                     bool is_far, bool is_unordered) {                   \
+    if(is_unordered) {                                                                   \
+      /* jump if either source is NaN or condition is expected */                        \
+      FLOATCMP2##_d(t0, Rs2, Rs1);                                                       \
+      beqz_nc(t0, l, is_far);                                                            \
+    } else {                                                                             \
+      /* jump if no NaN in source and condition is expected */                           \
+      FLOATCMP1##_d(t0, Rs1, Rs2);                                                       \
+      bnez_nc(t0, l, is_far);                                                            \
+    }                                                                                    \
   }
 
   INSN(ble, fle, flt);
@@ -848,14 +880,14 @@ void MacroAssembler::la(Register Rd, Label &label) {
 
 #undef INSN
 
-#define INSN(NAME, CMP)                                                              \
-  void MacroAssembler::float_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,  \
-                                    bool is_far, bool is_unordered) {                \
-    float_##CMP(Rs2, Rs1, l, is_far, is_unordered);                                  \
-  }                                                                                  \
-  void MacroAssembler::double_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l, \
-                                     bool is_far, bool is_unordered) {               \
-    double_##CMP(Rs2, Rs1, l, is_far, is_unordered);                                 \
+#define INSN(NAME, CMP)                                                                  \
+  void MacroAssembler::float_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,      \
+                                    bool is_far, bool is_unordered) {                    \
+    float_##CMP(Rs2, Rs1, l, is_far, is_unordered);                                      \
+  }                                                                                      \
+  void MacroAssembler::double_##NAME(FloatRegister Rs1, FloatRegister Rs2, Label &l,     \
+                                     bool is_far, bool is_unordered) {                   \
+    double_##CMP(Rs2, Rs1, l, is_far, is_unordered);                         \
   }
 
   INSN(bgt, blt);
@@ -1191,21 +1223,46 @@ void MacroAssembler::pop_CPU_state(bool restore_vectors, int vector_size_in_byte
 }
 
 static int patch_offset_in_jal(address branch, int64_t offset) {
-  assert(is_imm_in_range(offset, 20, 1), "offset is too large to be patched in one jal insrusction!\n");
-  Assembler::patch(branch, 31, 31, (offset >> 20) & 0x1);                       // offset[20]    ==> branch[31]
-  Assembler::patch(branch, 30, 21, (offset >> 1)  & 0x3ff);                     // offset[10:1]  ==> branch[30:21]
-  Assembler::patch(branch, 20, 20, (offset >> 11) & 0x1);                       // offset[11]    ==> branch[20]
-  Assembler::patch(branch, 19, 12, (offset >> 12) & 0xff);                      // offset[19:12] ==> branch[19:12]
-  return NativeInstruction::instruction_size;                                             // only one instruction
+  if (!NativeInstruction::is_compressed_instr(branch)) {
+    assert(is_imm_in_range(offset, 20, 1), "offset is too large to be patched in one jal instruction!\n");
+    Assembler::patch(branch, 31, 31, (offset >> 20) & 0x1);                       // offset[20]    ==> branch[31]
+    Assembler::patch(branch, 30, 21, (offset >> 1)  & 0x3ff);                     // offset[10:1]  ==> branch[30:21]
+    Assembler::patch(branch, 20, 20, (offset >> 11) & 0x1);                       // offset[11]    ==> branch[20]
+    Assembler::patch(branch, 19, 12, (offset >> 12) & 0xff);                      // offset[19:12] ==> branch[19:12]
+    return NativeInstruction::instruction_size;                                   // only one instruction
+  } else {  // we must patch it, so I don't check if current instruction is a compressed instruction because it must be.
+    assert(is_imm_in_range(offset, 11, 1), "offset is too large to be patched in one c.j instruction: use j_nc() instead of your j().\n");
+    Assembler::patch_c(branch, 2, 2, (offset & nth_bit(5)) >> 5);              // offset[5]     ==> branch[2]
+    Assembler::patch_c(branch, 5, 3, (offset & right_n_bits(4)) >> 1);         // offset[3:1]   ==> branch[5:3]
+    Assembler::patch_c(branch, 6, 6, (offset & nth_bit(7)) >> 7);              // offset[7]     ==> branch[6]
+    Assembler::patch_c(branch, 7, 7, (offset & nth_bit(6)) >> 6);              // offset[6]     ==> branch[7]
+    Assembler::patch_c(branch, 8, 8, (offset & nth_bit(10)) >> 10);            // offset[10]    ==> branch[8]
+    Assembler::patch_c(branch, 10, 9, (offset & right_n_bits(10)) >> 8);       // offset[9:8]   ==> branch[10:9]
+    Assembler::patch_c(branch, 11, 11, (offset & nth_bit(4)) >> 4);            // offset[4]     ==> branch[11]
+    Assembler::patch_c(branch, 12, 12, (offset & nth_bit(11)) >> 11);          // offset[11]    ==> branch[12]
+    return NativeInstruction::compressed_instruction_size;                     // only one instruction
+  }
 }
 
 static int patch_offset_in_conditional_branch(address branch, int64_t offset) {
-  assert(is_imm_in_range(offset, 12, 1), "offset is too large to be patched in one beq/bge/bgeu/blt/bltu/bne insrusction!\n");
-  Assembler::patch(branch, 31, 31, (offset >> 12) & 0x1);                       // offset[12]    ==> branch[31]
-  Assembler::patch(branch, 30, 25, (offset >> 5)  & 0x3f);                      // offset[10:5]  ==> branch[30:25]
-  Assembler::patch(branch, 7,  7,  (offset >> 11) & 0x1);                       // offset[11]    ==> branch[7]
-  Assembler::patch(branch, 11, 8,  (offset >> 1)  & 0xf);                       // offset[4:1]   ==> branch[11:8]
-  return NativeInstruction::instruction_size;                                   // only one instruction
+  if (!NativeInstruction::is_compressed_instr(branch)) {
+    assert(is_imm_in_range(offset, 12, 1),
+           "offset is too large to be patched in one beq/bge/bgeu/blt/bltu/bne insrusction!\n");
+    Assembler::patch(branch, 31, 31, (offset >> 12) & 0x1);                       // offset[12]    ==> branch[31]
+    Assembler::patch(branch, 30, 25, (offset >> 5) & 0x3f);                       // offset[10:5]  ==> branch[30:25]
+    Assembler::patch(branch, 7, 7, (offset >> 11) & 0x1);                         // offset[11]    ==> branch[7]
+    Assembler::patch(branch, 11, 8, (offset >> 1) & 0xf);                         // offset[4:1]   ==> branch[11:8]
+    return NativeInstruction::instruction_size;                                   // only one instruction
+  } else {
+    assert(is_imm_in_range(offset, 8, 1),
+            "offset is too large to be patched in one c.beqz/c.bnez instruction: use beqz_nc()/bnez.nc() instead.\n");
+    Assembler::patch_c(branch, 2, 2, (offset & nth_bit(5)) >> 5);
+    Assembler::patch_c(branch, 4, 3, (offset & right_n_bits(3)) >> 1);
+    Assembler::patch_c(branch, 6, 5, (offset & right_n_bits(8)) >> 6);
+    Assembler::patch_c(branch, 11, 10, (offset & right_n_bits(5)) >> 3);
+    Assembler::patch_c(branch, 12, 12, (offset & nth_bit(8)) >> 8);
+    return NativeInstruction::compressed_instruction_size;                     // only one instruction
+  }
 }
 
 static int patch_offset_in_pc_relative(address branch, int64_t offset) {
@@ -1216,18 +1273,24 @@ static int patch_offset_in_pc_relative(address branch, int64_t offset) {
 }
 
 static int patch_addr_in_movptr(address branch, address target) {
-  const int MOVPTR_INSTRUCTIONS_NUM = 6;                                        // lui + addi + slli + addi + slli + addi/jalr/load
+  // lui + addi + slli(C) + addi + slli(C) + addi/jalr/load
+  const int size = !UseCExt ?
+          6 * NativeInstruction::instruction_size :
+          4 * NativeInstruction::instruction_size + 2 * NativeInstruction::compressed_instruction_size;
   int32_t lower = ((intptr_t)target << 36) >> 36;
   int64_t upper = ((intptr_t)target - lower) >> 28;
   Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.             target[47:28] + target[27] ==> branch[31:12]
   Assembler::patch(branch + 4,  31, 20, (lower >> 16) & 0xfff);                 // Addi.            target[27:16] ==> branch[31:20]
-  Assembler::patch(branch + 12, 31, 20, (lower >> 5) & 0x7ff);                  // Addi.            target[15: 5] ==> branch[31:20]
-  Assembler::patch(branch + 20, 31, 20, lower & 0x1f);                          // Addi/Jalr/Load.  target[ 4: 0] ==> branch[31:20]
-  return MOVPTR_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
+  Assembler::patch(branch + (!UseCExt ? 12 : 10), 31, 20, (lower >> 5) & 0x7ff);  // Addi.    target[15: 5] ==> branch[31:20]
+  Assembler::patch(branch + (!UseCExt ? 20 : 16), 31, 20, lower & 0x1f);  // Addi/Jalr/Load.  target[ 4: 0] ==> branch[31:20]
+  return size;
 }
 
 static int patch_imm_in_li64(address branch, address target) {
-  const int LI64_INSTRUCTIONS_NUM = 8;                                          // lui + addi + slli + addi + slli + addi + slli + addi
+  // lui + addi + slli(C) + addi + slli(C) + addi + slli(C) + addi
+  const int size = !UseCExt ?
+          8 * NativeInstruction::instruction_size :
+          5 * NativeInstruction::instruction_size + 3 * NativeInstruction::compressed_instruction_size;
   int64_t lower = (intptr_t)target & 0xffffffff;
   lower = lower - ((lower << 44) >> 44);
   int64_t tmp_imm = ((uint64_t)((intptr_t)target & 0xffffffff00000000)) + (uint64_t)lower;
@@ -1241,10 +1304,10 @@ static int patch_imm_in_li64(address branch, address target) {
   Assembler::patch(branch + 0,  31, 12, tmp_upper & 0xfffff);                       // Lui.
   Assembler::patch(branch + 4,  31, 20, tmp_lower & 0xfff);                         // Addi.
   // Load the rest 32 bits.
-  Assembler::patch(branch + 12, 31, 20, ((int32_t)lower >> 20) & 0xfff);            // Addi.
-  Assembler::patch(branch + 20, 31, 20, (((intptr_t)target << 44) >> 52) & 0xfff);  // Addi.
-  Assembler::patch(branch + 28, 31, 20, (intptr_t)target & 0xff);                   // Addi.
-  return LI64_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
+  Assembler::patch(branch + (!UseCExt ? 12 : 10), 31, 20, ((int32_t)lower >> 20) & 0xfff);            // Addi.
+  Assembler::patch(branch + (!UseCExt ? 20 : 16), 31, 20, (((intptr_t)target << 44) >> 52) & 0xfff);  // Addi.
+  Assembler::patch(branch + (!UseCExt ? 28 : 22), 31, 20, (intptr_t)target & 0xff);                   // Addi.
+  return size;
 }
 
 static int patch_imm_in_li32(address branch, int32_t target) {
@@ -1256,31 +1319,6 @@ static int patch_imm_in_li32(address branch, int32_t target) {
   Assembler::patch(branch + 0,  31, 12, (upper >> 12) & 0xfffff);               // Lui.
   Assembler::patch(branch + 4,  31, 20, lower & 0xfff);                         // Addiw.
   return LI32_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
-}
-
-static long get_offset_of_jal(address insn_addr) {
-  assert_cond(insn_addr != NULL);
-  long offset = 0;
-  unsigned insn = *(unsigned*)insn_addr;
-  long val = (long)Assembler::sextract(insn, 31, 12);
-  offset |= ((val >> 19) & 0x1) << 20;
-  offset |= (val & 0xff) << 12;
-  offset |= ((val >> 8) & 0x1) << 11;
-  offset |= ((val >> 9) & 0x3ff) << 1;
-  offset = (offset << 43) >> 43;
-  return offset;
-}
-
-static long get_offset_of_conditional_branch(address insn_addr) {
-  long offset = 0;
-  assert_cond(insn_addr != NULL);
-  unsigned insn = *(unsigned*)insn_addr;
-  offset = (long)Assembler::sextract(insn, 31, 31);
-  offset = (offset << 12) | (((long)(Assembler::sextract(insn, 7, 7) & 0x1)) << 11);
-  offset = offset | (((long)(Assembler::sextract(insn, 30, 25) & 0x3f)) << 5);
-  offset = offset | (((long)(Assembler::sextract(insn, 11, 8) & 0xf)) << 1);
-  offset = (offset << 41) >> 41;
-  return offset;
 }
 
 static long get_offset_of_pc_relative(address insn_addr) {
@@ -1295,9 +1333,9 @@ static long get_offset_of_pc_relative(address insn_addr) {
 static address get_target_of_movptr(address insn_addr) {
   assert_cond(insn_addr != NULL);
   intptr_t target_address = (((int64_t)Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12)) & 0xfffff) << 28;    // Lui.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20)) << 16;                        // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[3], 31, 20)) << 5;                         // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[5], 31, 20));                              // Addi/Jalr/Load.
+  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20)) << 16;                                     // Addi.
+  target_address += ((int64_t)Assembler::sextract(((unsigned*)(insn_addr - (!UseCExt ? 0 : 2)))[3], 31, 20)) << 5;         // Addi.
+  target_address += ((int64_t)Assembler::sextract(((unsigned*)(insn_addr - (!UseCExt ? 0 : 4)))[5], 31, 20));              // Addi/Jalr/Load.
   return (address) target_address;
 }
 
@@ -1305,9 +1343,9 @@ static address get_target_of_li64(address insn_addr) {
   assert_cond(insn_addr != NULL);
   intptr_t target_address = (((int64_t)Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12)) & 0xfffff) << 44;    // Lui.
   target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20)) << 32;                        // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[3], 31, 20)) << 20;                        // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[5], 31, 20)) << 8;                         // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[7], 31, 20));                              // Addi.
+  target_address += ((int64_t)Assembler::sextract(((unsigned*)(insn_addr - (!UseCExt ? 0 : 2)))[3], 31, 20)) << 20;        // Addi.
+  target_address += ((int64_t)Assembler::sextract(((unsigned*)(insn_addr - (!UseCExt ? 0 : 4)))[5], 31, 20)) << 8;         // Addi.
+  target_address += ((int64_t)Assembler::sextract(((unsigned*)(insn_addr - (!UseCExt ? 0 : 6)))[7], 31, 20));              // Addi.
   return (address)target_address;
 }
 
@@ -1347,9 +1385,9 @@ address MacroAssembler::target_addr_for_insn(address insn_addr) {
   long offset = 0;
   assert_cond(insn_addr != NULL);
   if (NativeInstruction::is_jal_at(insn_addr)) {                     // jal
-    offset = get_offset_of_jal(insn_addr);
+    offset = get_offset_of_jal(*(unsigned*)insn_addr);
   } else if (NativeInstruction::is_branch_at(insn_addr)) {           // beq/bge/bgeu/blt/bltu/bne
-    offset = get_offset_of_conditional_branch(insn_addr);
+    offset = get_offset_of_conditional_branch(*(unsigned*)insn_addr);
   } else if (NativeInstruction::is_pc_relative_at(insn_addr)) {      // auipc, addi/jalr/load
     offset = get_offset_of_pc_relative(insn_addr);
   } else if (NativeInstruction::is_movptr_at(insn_addr)) {           // movptr
@@ -1387,7 +1425,7 @@ void MacroAssembler::reinit_heapbase() {
     } else {
       int32_t offset = 0;
       la_patchable(xheapbase, ExternalAddress((address)CompressedOops::ptrs_base_addr()), offset);
-      ld(xheapbase, Address(xheapbase, offset));
+      ld_nc(xheapbase, Address(xheapbase, offset));
     }
   }
 }
@@ -1407,7 +1445,7 @@ void MacroAssembler::mvw(Register Rd, int32_t imm32) {
 void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
   code_section()->relocate(pc(), dest.rspec());
-  movptr(Rd, dest.target());
+  movptr(Rd, dest.target(), false);
 }
 
 void MacroAssembler::mv(Register Rd, address addr) {
@@ -2704,10 +2742,10 @@ void MacroAssembler::far_jump(Address entry, CodeBuffer *cbuf, Register tmp) {
     // the code cache cannot exceed 2Gb.
     la_patchable(tmp, entry, offset);
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
-    jalr(x0, tmp, offset);
+    jalr_nc(x0, tmp, offset);
   } else {
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
-    j(entry);
+    j_nc(entry);
   }
 }
 
@@ -2721,7 +2759,7 @@ void MacroAssembler::far_call(Address entry, CodeBuffer *cbuf, Register tmp) {
     // the code cache cannot exceed 2Gb.
     la_patchable(tmp, entry, offset);
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
-    jalr(x1, tmp, offset); // link
+    jalr_nc(x1, tmp, offset); // link
   } else {
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
     jal(entry); // link
@@ -2984,7 +3022,7 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
     auipc(reg1, (int32_t)distance + 0x800);
     offset = ((int32_t)distance << 20) >> 20;
   } else {
-    movptr_with_offset(reg1, dest.target(), offset);
+    movptr_with_offset(reg1, dest.target(), offset, false);
   }
 }
 
@@ -3006,7 +3044,7 @@ void MacroAssembler::remove_frame(int framesize) {
   add(sp, sp, framesize);
 }
 
-void MacroAssembler::reserved_stack_check() {
+void MacroAssembler::reserved_stack_check(bool compressed) {
     // testing if reserved zone needs to be enabled
     Label no_reserved_zone_enabling;
 
@@ -3017,7 +3055,7 @@ void MacroAssembler::reserved_stack_check() {
     mv(c_rarg0, xthread);
     int32_t offset = 0;
     la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone)), offset);
-    jalr(x1, t0, offset);
+    jalr_nc(x1, t0, offset);
     leave();
 
     // We have already removed our own frame.
@@ -3025,8 +3063,8 @@ void MacroAssembler::reserved_stack_check() {
     // called by our caller.
     offset = 0;
     la_patchable(t0, RuntimeAddress(StubRoutines::throw_delayed_StackOverflowError_entry()), offset);
-    jalr(x0, t0, offset);
-    should_not_reach_here();
+    jalr_nc(x0, t0, offset);
+    should_not_reach_here(compressed);
 
     bind(no_reserved_zone_enabling);
 }
@@ -3114,9 +3152,9 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
   if (cbuf != NULL) { cbuf->set_insts_mark(); }
   relocate(entry.rspec());
   if (!far_branches()) {
-    jal(entry.target());
+    jal_nc(entry.target());
   } else {
-    jal(pc());
+    jal_nc(pc());
   }
   // just need to return a non-null address
   postcond(pc() != badAddress);
@@ -3125,7 +3163,7 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
 
 address MacroAssembler::ic_call(address entry, jint method_index) {
   RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index);
-  movptr(t1, (address)Universe::non_oop_word());
+  movptr(t1, (address)Universe::non_oop_word(), false);
   assert_cond(entry != NULL);
   return trampoline_call(Address(entry, rh));
 }
@@ -3165,8 +3203,8 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
   // - load the call
   // - call
   Label target;
-  ld(t0, target);  // auipc + ld
-  jr(t0);          // jalr
+  ld_nc(t0, target);  // auipc + ld
+  jr_nc(t0);          // jalr
   bind(target);
   assert(offset() - stub_start_offset == NativeCallTrampolineStub::data_offset,
          "should be");
@@ -3212,7 +3250,7 @@ void MacroAssembler::cmpptr(Register src1, Address src2, Label& equal) {
   assert_different_registers(src1, t0);
   int32_t offset;
   la_patchable(t0, src2, offset);
-  ld(t0, Address(t0, offset));
+  ld_nc(t0, Address(t0, offset));
   beq(src1, t0, equal);
 }
 

--- a/src/hotspot/cpu/riscv64/nativeInst_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/nativeInst_riscv64.cpp
@@ -39,64 +39,145 @@
 #include "c1/c1_Runtime1.hpp"
 #endif
 
+uint32_t NativeInstruction::extract_rs1(address instr, int &size) {
+  assert_cond(instr != NULL);
+  if (is_compressed_instr(instr)) {
+    size = compressed_instruction_size;
+    uint16_t op = Assembler::extract_c(((uint16_t*)instr)[0], 1, 0);
+    switch (op) {
+      case 0b00: {
+        return Assembler::extract_c(((uint16_t*)instr)[0], 9, 7);
+      }
+      case 0b01: {
+        if (!is_set_nth_bit(((uint16_t*)instr)[0], 15)) {
+          return Assembler::extract_c(((uint16_t*)instr)[0], 11, 7);
+        } else {
+          return Assembler::extract_c(((uint16_t*)instr)[0], 9, 7);
+        }
+      }
+      case 0b10: {
+        return Assembler::extract_c(((uint16_t*)instr)[0], 11, 7);
+      }
+      default:
+        ShouldNotReachHere();
+    }
+    return 0;
+  } else {
+    size = instruction_size;
+    return Assembler::extract(((unsigned*)instr)[0], 19, 15);
+  }
+}
+
+uint32_t NativeInstruction::extract_rs2(address instr, int &size) {
+  assert_cond(instr != NULL);
+  if (is_compressed_instr(instr)) {
+    size = compressed_instruction_size;
+    uint16_t op = Assembler::extract_c(((uint16_t*)instr)[0], 1, 0);
+    switch (op) {
+      case 0b00: {
+        return Assembler::extract_c(((uint16_t*)instr)[0], 4, 2);
+      }
+      case 0b01: {
+        if (!is_set_nth_bit(((uint16_t*)instr)[0], 15)) {
+          ShouldNotReachHere();
+          return 0;
+        } else {
+          return Assembler::extract_c(((uint16_t*)instr)[0], 4, 2);
+        }
+      }
+      case 0b10: {
+        return Assembler::extract_c(((uint16_t*)instr)[0], 6, 2);
+      }
+      default:
+        ShouldNotReachHere();
+    }
+    return 0;
+  } else {
+    size = instruction_size;
+    return Assembler::extract(((unsigned*)instr)[0], 24, 20);
+  }
+}
+
+uint32_t NativeInstruction::extract_rd(address instr, int &size) {
+  assert_cond(instr != NULL);
+  if (is_compressed_instr(instr)) {
+    size = compressed_instruction_size;
+    uint16_t op = Assembler::extract_c(((uint16_t*)instr)[0], 1, 0);
+    switch (op) {
+      case 0b00: {
+        return Assembler::extract_c(((uint16_t*)instr)[0], 4, 2);
+      }
+      case 0b01: {
+        if (!is_set_nth_bit(((uint16_t*)instr)[0], 15)) {
+          return Assembler::extract_c(((uint16_t*)instr)[0], 11, 7);
+        } else {
+          return Assembler::extract_c(((uint16_t*)instr)[0], 9, 7);
+        }
+      }
+      case 0b10: {
+        return Assembler::extract_c(((uint16_t*)instr)[0], 11, 7);
+      }
+      default:
+        ShouldNotReachHere();
+    }
+    return 0;
+  } else {
+    size = instruction_size;
+    return Assembler::extract(((unsigned*)instr)[0], 11, 7);
+  }
+}
+
 bool NativeInstruction::is_pc_relative_at(address instr) {
   // auipc + jalr
   // auipc + addi
   // auipc + load
   // auipc + fload_load
-  if ((is_auipc_at(instr)) &&
-      (is_addi_at(instr + 4) || is_jalr_at(instr + 4) || is_load_at(instr + 4) || is_float_load_at(instr + 4)) &&
-      check_pc_relative_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  return (is_auipc_at(instr)) &&
+         (is_addi_at(instr + instruction_size) ||
+          is_jalr_at(instr + instruction_size) ||
+          is_load_at(instr + instruction_size) ||
+          is_float_load_at(instr + instruction_size)) &&
+         check_pc_relative_data_dependency(instr);
 }
 
 // ie:ld(Rd, Label)
 bool NativeInstruction::is_load_pc_relative_at(address instr) {
-  if (is_auipc_at(instr) && // auipc
-      is_ld_at(instr + 4) && // ld
-      check_load_pc_relative_data_dependency(instr)) {
-      return true;
-  }
-  return false;
+  return is_auipc_at(instr) && // auipc
+         is_ld_at(instr + instruction_size) && // ld
+         check_load_pc_relative_data_dependency(instr);
 }
 
 bool NativeInstruction::is_movptr_at(address instr) {
-  if (is_lui_at(instr) && // Lui
-      is_addi_at(instr + 4) && // Addi
-      is_slli_shift_at(instr + 8, 11) && // Slli Rd, Rs, 11
-      is_addi_at(instr + 12) && // Addi
-      is_slli_shift_at(instr + 16, 5) && // Slli Rd, Rs, 5
-      (is_addi_at(instr + 20) || is_jalr_at(instr + 20) || is_load_at(instr + 20)) && // Addi/Jalr/Load
-      check_movptr_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  address pos = instr;
+  int size = 0;
+  return is_lui_at(pos) && // Lui
+         is_addi_at(pos += instruction_size) && // Addi
+         is_slli_shift_at(pos += instruction_size, 11, size) && // Slli Rd, Rs, 11
+         is_addi_at(pos += size) && // Addi
+         is_slli_shift_at(pos += instruction_size, 5, size) && // Slli Rd, Rs, 5
+         (is_addi_at(pos += size) || is_jalr_at(pos) || is_load_at(pos)) && // Addi/Jalr/Load
+         check_movptr_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li32_at(address instr) {
-  if (is_lui_at(instr) && // lui
-      is_addiw_at(instr + 4) && // addiw
-      check_li32_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  address pos = instr;
+  return is_lui_at(pos) && // lui
+         is_addiw_at(pos += instruction_size) && // addiw
+         check_li32_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li64_at(address instr) {
-  if (is_lui_at(instr) && // lui
-      is_addi_at(instr + 4) && // addi
-      is_slli_shift_at(instr + 8, 12)&&  // Slli Rd, Rs, 12
-      is_addi_at(instr + 12) && // addi
-      is_slli_shift_at(instr + 16, 12) && // Slli Rd, Rs, 12
-      is_addi_at(instr + 20) && // addi
-      is_slli_shift_at(instr + 24, 8) && // Slli Rd, Rs, 8
-      is_addi_at(instr + 28) && // addi
-      check_li64_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  address pos = instr;
+  int size = 0;
+  return is_lui_at(pos) && // lui
+         is_addi_at(pos += instruction_size) && // addi
+         is_slli_shift_at(pos += instruction_size, 12, size) &&  // Slli Rd, Rs, 12
+         is_addi_at(pos += size) && // addi
+         is_slli_shift_at(pos += instruction_size, 12, size) &&  // Slli Rd, Rs, 12
+         is_addi_at(pos += size) && // addi
+         is_slli_shift_at(pos += instruction_size, 8, size) &&   // Slli Rd, Rs, 8
+         is_addi_at(pos += size) && // addi
+         check_li64_data_dependency(instr);
 }
 
 void NativeCall::verify() {
@@ -203,7 +284,7 @@ void NativeMovConstReg::set_data(intptr_t x) {
   } else {
     // Store x into the instruction stream.
     MacroAssembler::pd_patch_instruction_size(instruction_address(), (address)x);
-    ICache::invalidate_range(instruction_address(), movptr_instruction_size);
+    ICache::invalidate_range(instruction_address(), get_movptr_instruction_size());
   }
 
   // Find and replace the oop/metadata corresponding to this
@@ -341,7 +422,7 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
 
   assert(dest == SharedRuntime::get_handle_wrong_method_stub(), "expected fixed destination of patch");
 
-  assert(nativeInstruction_at(verified_entry)->is_jump_or_nop() ||
+  assert(nativeInstruction_at(verified_entry)->is_jump_or_nop_nc() ||
          nativeInstruction_at(verified_entry)->is_sigill_zombie_not_entrant(),
          "riscv64 cannot replace non-jump with jump");
 
@@ -371,14 +452,14 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
 void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
   NativeGeneralJump* n_jump = (NativeGeneralJump*)code_pos;
 
-  CodeBuffer cb(code_pos, instruction_size);
+  CodeBuffer cb(code_pos, get_instruction_size());
   MacroAssembler a(&cb);
 
   int32_t offset = 0;
-  a.movptr_with_offset(t0, entry, offset); // lui, addi, slli, addi, slli
-  a.jalr(x0, t0, offset); // jalr
+  a.movptr_with_offset(t0, entry, offset, false); // lui, addi, slli, addi, slli
+  a.jalr_nc(x0, t0, offset); // jalr
 
-  ICache::invalidate_range(code_pos, instruction_size);
+  ICache::invalidate_range(code_pos, get_instruction_size());
 }
 
 // MT-safe patching of a long jump instruction.

--- a/src/hotspot/cpu/riscv64/nativeInst_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/nativeInst_riscv64.hpp
@@ -53,7 +53,8 @@ class NativeInstruction {
   friend bool is_NativeCallTrampolineStub_at(address);
  public:
   enum {
-    instruction_size = 4
+    instruction_size = 4,
+    compressed_instruction_size = 2,
   };
 
   juint encoding() const {
@@ -65,26 +66,49 @@ class NativeInstruction {
   bool is_call()                            const { return is_call_at(addr_at(0));        }
   bool is_jump()                            const { return is_jump_at(addr_at(0));        }
 
+  static bool is_compressed_instr(address instr) {
+    if ((((unsigned*)instr)[0] & 0b11) == 0b11) {
+      return false;
+    }
+    assert((((uint16_t *)instr)[0] & 0b11) != 0b11, "seems instr is not an illegal instruction beginning: 0x%x", ((unsigned*)instr)[0]);
+    return true;
+  }
+  static int instr_size(address instr) {
+    return is_compressed_instr(instr) ? compressed_instruction_size : instruction_size;
+  }
   static bool is_jal_at(address instr)        { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b1101111; }
   static bool is_jalr_at(address instr)       { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b1100111 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
+                                                                                    Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
   static bool is_branch_at(address instr)     { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b1100011; }
   static bool is_ld_at(address instr)         { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0000011 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b011); }
+                                                                                    Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b011); }
   static bool is_load_at(address instr)       { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0000011; }
   static bool is_float_load_at(address instr) { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0000111; }
   static bool is_auipc_at(address instr)      { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0010111; }
   static bool is_jump_at(address instr)       { assert_cond(instr != NULL); return (is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr)); }
   static bool is_addi_at(address instr)       { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0010011 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
+                                                                                    Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
   static bool is_addiw_at(address instr)      { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0011011 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
+                                                                                    Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
   static bool is_lui_at(address instr)        { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0110111; }
-  static bool is_slli_shift_at(address instr, uint32_t shift) {
+  static bool is_slli_shift_at(address instr, uint32_t shift) { int size = 0; return is_slli_shift_at(instr, shift, size); }
+  static uint16_t extract_c_slli(address instr) {
+    uint16_t low5 = Assembler::extract_c(((uint16_t*)instr)[0], 6, 2);
+    uint16_t high1 = Assembler::extract_c(((uint16_t*)instr)[0], 12, 12);
+    return (high1 << 5 | low5);
+  }
+  static bool is_slli_shift_at(address instr, uint32_t shift, int &size) {
     assert_cond(instr != NULL);
+    if (is_compressed_instr(instr)) {
+      return Assembler::extract_c(((uint16_t*)instr)[0], 15, 13) == 0b000 &&
+             Assembler::extract_c(((uint16_t*)instr)[0], 1, 0) == 0b10 &&
+             extract_c_slli(instr) == shift &&
+             (size = compressed_instruction_size);
+    }
     return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0010011 && // opcode field
             Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b001 &&   // funct3 field, select the type of operation
-            Assembler::extract(((unsigned*)instr)[0], 25, 20) == shift);    // shamt field
+            Assembler::extract(((unsigned*)instr)[0], 25, 20) == shift) &&  // shamt field
+            (size = instruction_size);
   }
 
   // return true if the (index1~index2) field of instr1 is equal to (index3~index4) field of instr2, otherwise false
@@ -92,6 +116,13 @@ class NativeInstruction {
     assert_cond(instr1 != NULL && instr2 != NULL);
     return Assembler::extract(((unsigned*)instr1)[0], index1, index2) == Assembler::extract(((unsigned*)instr2)[0], index3, index4);
   }
+
+  static uint32_t extract_rs1(address instr) { int size = 0; return extract_rs1(instr, size); }
+  static uint32_t extract_rs2(address instr) { int size = 0; return extract_rs2(instr, size); }
+  static uint32_t extract_rd(address instr) { int size = 0; return extract_rd(instr, size); }
+  static uint32_t extract_rs1(address instr, int &size);
+  static uint32_t extract_rs2(address instr, int &size);
+  static uint32_t extract_rd(address instr, int &size);
 
   // the instruction sequence of movptr is as below:
   //     lui
@@ -101,15 +132,21 @@ class NativeInstruction {
   //     slli
   //     addi/jalr/load
   static bool check_movptr_data_dependency(address instr) {
-    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7)       &&     // check the rs1 field of addi and the rd field of lui
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7)   &&     // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 4, 11, 7)   &&     // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 8, 11, 7)   &&     // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 8, 11, 7)  &&     // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 12, 11, 7) &&     // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 12, 11, 7) &&     // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 16, 11, 7) &&     // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 20, 19, 15, instr + 16, 11, 7);       // check the rs1 field of addi/jalr/load and the rd field of slli
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instr_size(slli1);
+    address slli2 = addi2 + instruction_size;
+    address final = slli2 + instr_size(slli2);
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(final) == extract_rd(slli2);
   }
 
   // the instruction sequence of li64 is as below:
@@ -121,44 +158,61 @@ class NativeInstruction {
   //     addi
   //     slli
   //     addi
-  static bool check_li64_data_dependency(address instr) {
-    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7)       &&  // check the rs1 field of addi and the rd field of lui
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7)   &&  // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 4, 11, 7)   &&  // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 8, 11, 7)   &&  // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 8, 11, 7)  &&  // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 12, 11, 7) &&  // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 12, 11, 7) &&  // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 16, 11, 7) &&  // check the rs1 field and the rd field fof slli
-           compare_instr_field(instr + 20, 19, 15, instr + 16, 11, 7) &&  // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 20, 19, 15, instr + 20, 11, 7) &&  // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 24, 19, 15, instr + 20, 11, 7) &&  // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 24, 19, 15, instr + 24, 11, 7) &&  // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 28, 19, 15, instr + 24, 11, 7) &&  // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 28, 19, 15, instr + 28, 11, 7);    // check the rs1 field and the rd field of addi
+  static bool check_li64_data_dependency(address instr) {  // FIXME: maybe retrive back origin code because we can only optimize 'slli' here.
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instr_size(slli1);
+    address slli2 = addi2 + instruction_size;
+    address addi3 = slli2 + instr_size(slli2);
+    address slli3 = addi3 + instruction_size;
+    address addi4 = slli3 + instr_size(slli3);
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(addi4);
   }
 
   // the instruction sequence of li32 is as below:
   //     lui
   //     addiw
   static bool check_li32_data_dependency(address instr) {
-    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7) &&     // check the rs1 field of addiw and the rd field of lui
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7);   // check the rs1 field and the rd field of addiw
+    address lui = instr;
+    address addiw = lui + instruction_size;
+
+    return extract_rs1(addiw) == extract_rd(lui) &&
+           extract_rs1(addiw) == extract_rd(addiw);
   }
 
   // the instruction sequence of pc-relative is as below:
   //     auipc
   //     jalr/addi/load/float_load
   static bool check_pc_relative_data_dependency(address instr) {
-    return compare_instr_field(instr, 11, 7, instr + 4, 19, 15);          // check the rd field of auipc and the rs1 field of jalr/addi/load/float_load
+    address auipc = instr;
+    address final = auipc + instruction_size;
+
+    return extract_rs1(final) == extract_rd(auipc);
   }
 
   // the instruction sequence of load_label is as below:
   //     auipc
   //     load
   static bool check_load_pc_relative_data_dependency(address instr) {
-    return compare_instr_field(instr, 11, 7, instr + 4, 11, 7) &&      // check the rd field of auipc and the rd field of load
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7);   // check the rs1 field of load and the rd field of load
+    address auipc = instr;
+    address load = auipc + instruction_size;
+
+    return extract_rd(load) == extract_rd(auipc) &&
+           extract_rs1(load) == extract_rd(load);
   }
 
   static bool is_movptr_at(address instr);
@@ -168,6 +222,7 @@ class NativeInstruction {
   static bool is_load_pc_relative_at(address branch);
 
   static bool is_call_at(address instr) {
+    assert(!is_compressed_instr(instr), "we need to reserve the 4-byte instruction to handle all cases");
     if (is_jal_at(instr) || is_jalr_at(instr)) {
       return true;
     }
@@ -176,9 +231,11 @@ class NativeInstruction {
   static bool is_lwu_to_zr(address instr);
 
   inline bool is_nop();
+  inline bool is_compressed_nop();
+  inline bool is_uncompressed_nop();
   inline bool is_illegal();
   inline bool is_return();
-  inline bool is_jump_or_nop();
+  inline bool is_jump_or_nop_nc();
   inline bool is_cond_jump();
   bool is_safepoint_poll();
   bool is_sigill_zombie_not_entrant();
@@ -189,6 +246,7 @@ class NativeInstruction {
 
   jint int_at(int offset) const        { return *(jint*) addr_at(offset); }
   juint uint_at(int offset) const      { return *(juint*) addr_at(offset); }
+  jushort uint16_at(int offset) const { return *(jushort *) addr_at(offset); }
 
   address ptr_at(int offset) const     { return *(address*) addr_at(offset); }
 
@@ -318,12 +376,22 @@ inline NativeCall* nativeCall_before(address return_address) {
 class NativeMovConstReg: public NativeInstruction {
  public:
   enum RISCV64_specific_constants {
-    movptr_instruction_size             =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr().
+    movptr_instruction_size      =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr().
+    compressed_movptr_instruction_size  =    4 * NativeInstruction::instruction_size + 2 * NativeInstruction::compressed_instruction_size, // lui, addi, slli(C), addi, slli(C), addi.  See movptr().
     movptr_with_offset_instruction_size =    5 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli. See movptr_with_offset().
+    compressed_movptr_with_offset_instruction_size = 3 * NativeInstruction::instruction_size + 2 * NativeInstruction::compressed_instruction_size, // lui, addi, slli(C), addi, slli(C). See movptr_with_offset().
     load_pc_relative_instruction_size   =    2 * NativeInstruction::instruction_size, // auipc, ld
     instruction_offset                  =    0,
     displacement_offset                 =    0
   };
+
+  static const int get_movptr_with_offset_instruction_size() {
+    return !UseCExt ? movptr_with_offset_instruction_size : compressed_movptr_with_offset_instruction_size;
+  }
+
+  static const int get_movptr_instruction_size() {
+    return !UseCExt ? movptr_instruction_size : compressed_movptr_instruction_size;
+  }
 
   address instruction_address() const       { return addr_at(instruction_offset); }
   address next_instruction_address() const  {
@@ -333,12 +401,12 @@ class NativeMovConstReg: public NativeInstruction {
     // However, when the instruction at 5 * instruction_size isn't addi,
     // the next instruction address should be addr_at(5 * instruction_size)
     if (nativeInstruction_at(instruction_address())->is_movptr()) {
-      if (is_addi_at(addr_at(movptr_with_offset_instruction_size))) {
+      if (is_addi_at(addr_at(get_movptr_with_offset_instruction_size()))) {
         // Assume: lui, addi, slli, addi, slli, addi
-        return addr_at(movptr_instruction_size);
+        return addr_at(get_movptr_instruction_size());
       } else {
         // Assume: lui, addi, slli, addi, slli
-        return addr_at(movptr_with_offset_instruction_size);
+        return addr_at(get_movptr_with_offset_instruction_size());
       }
     } else if (is_load_pc_relative_at(instruction_address())) {
       // Assume: auipc, ld
@@ -353,7 +421,7 @@ class NativeMovConstReg: public NativeInstruction {
 
   void flush() {
     if (!maybe_cpool_ref(instruction_address())) {
-      ICache::invalidate_range(instruction_address(), movptr_instruction_size);
+      ICache::invalidate_range(instruction_address(), get_movptr_instruction_size());
     }
   }
 
@@ -422,10 +490,10 @@ inline NativeMovRegMem* nativeMovRegMem_at (address addr) {
 class NativeJump: public NativeInstruction {
  public:
   enum RISCV64_specific_constants {
-    instruction_size            =    4,
+    instruction_size            =    NativeInstruction::instruction_size,
     instruction_offset          =    0,
     data_offset                 =    0,
-    next_instruction_offset     =    4
+    next_instruction_offset     =    NativeInstruction::instruction_size
   };
 
   address instruction_address() const       { return addr_at(instruction_offset); }
@@ -459,11 +527,17 @@ inline NativeJump* nativeJump_at(address addr) {
 class NativeGeneralJump: public NativeJump {
 public:
   enum RISCV64_specific_constants {
-    instruction_size            =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, jalr
+    instruction_size     =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, jalr
+    compressed_instruction_size =    4 * NativeInstruction::instruction_size + 2 * NativeInstruction::compressed_instruction_size, // lui, addi, slli(C), addi, slli(C), jalr
     instruction_offset          =    0,
     data_offset                 =    0,
-    next_instruction_offset     =    6 * NativeInstruction::instruction_size  // lui, addi, slli, addi, slli, jalr
+    normal_next_instruction_offset     =    6 * NativeInstruction::instruction_size,  // lui, addi, slli, addi, slli, jalr
+    compressed_next_instruction_offset =    4 * NativeInstruction::instruction_size + 2 * NativeInstruction::compressed_instruction_size  // lui, addi, slli(C), addi, slli(C), jalr
   };
+
+  static const int get_instruction_size() {
+    return !UseCExt ? instruction_size : compressed_instruction_size;
+  }
 
   address jump_destination() const;
 
@@ -484,13 +558,27 @@ class NativeIllegalInstruction: public NativeInstruction {
   static void insert(address code_pos);
 };
 
-inline bool NativeInstruction::is_nop()         {
-  uint32_t insn = *(uint32_t*)addr_at(0);
+inline bool NativeInstruction::is_nop() {
+  return is_compressed_nop() || is_uncompressed_nop();
+}
+
+inline bool NativeInstruction::is_compressed_nop() {
+  address instr_addr = addr_at(0);
+  if (is_compressed_instr(instr_addr)) {
+    uint16_t insn = *(uint16_t*)instr_addr;
+    return insn == 0x1;
+  }
+  return false;
+}
+
+inline bool NativeInstruction::is_uncompressed_nop() {
+  address instr_addr = addr_at(0);
+  uint32_t insn = *(uint32_t*)instr_addr;
   return insn == 0x13;
 }
 
-inline bool NativeInstruction::is_jump_or_nop() {
-  return is_nop() || is_jump();
+inline bool NativeInstruction::is_jump_or_nop_nc() {
+  return is_uncompressed_nop() || is_jump();
 }
 
 // Call trampoline stubs.

--- a/src/hotspot/cpu/riscv64/register_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/register_riscv64.hpp
@@ -59,7 +59,11 @@ class RegisterImpl: public AbstractRegisterImpl {
   enum {
     number_of_registers      = 32,
     number_of_byte_registers = 32,
-    max_slots_per_register   = 2
+    max_slots_per_register   = 2,
+
+    // C-Ext: integer registers in the range of [x8~x15] are correspond for RVC. Please see Table 16.2 in spec.
+    compressed_register_base = 8,
+    compressed_register_top  = 15,
   };
 
   // derived registers, offsets, and addresses
@@ -72,10 +76,13 @@ class RegisterImpl: public AbstractRegisterImpl {
 
   // accessors
   int   encoding() const                         { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+  int   compressed_encoding() const              { assert(is_compressed_valid(), "invalid compressed register"); return ((intptr_t)this - compressed_register_base); }
   bool  is_valid() const                         { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
+  bool  is_compressed_valid() const              { return compressed_register_base <= (intptr_t)this && (intptr_t)this <= compressed_register_top; }
   bool  has_byte_register() const                { return 0 <= (intptr_t)this && (intptr_t)this < number_of_byte_registers; }
   const char* name() const;
   int   encoding_nocheck() const                 { return (intptr_t)this; }
+  int   compressed_encoding_nocheck() const      { return ((intptr_t)this - compressed_register_base); }
 
   // Return the bit which represents this register.  This is intended
   // to be ORed into a bitmask: for usage see class RegSet below.
@@ -132,7 +139,11 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
  public:
   enum {
     number_of_registers     = 32,
-    max_slots_per_register  = 2
+    max_slots_per_register  = 2,
+
+    // C-Ext: float registers in the range of [f8~f15] are correspond for RVC. Please see Table 16.2 in spec.
+    compressed_register_base = 8,
+    compressed_register_top  = 15,
   };
 
   // construction
@@ -145,8 +156,11 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
 
   // accessors
   int   encoding() const                          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+  int   compressed_encoding() const               { assert(is_compressed_valid(), "invalid compressed register"); return ((intptr_t)this - compressed_register_base); }
   int   encoding_nocheck() const                         { return (intptr_t)this; }
+  int   compressed_encoding_nocheck() const       { return ((intptr_t)this - compressed_register_base); }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
+  bool  is_compressed_valid() const               { return compressed_register_base <= (intptr_t)this && (intptr_t)this <= compressed_register_top; }
   const char* name() const;
 
 };

--- a/src/hotspot/cpu/riscv64/riscv64.ad
+++ b/src/hotspot/cpu/riscv64/riscv64.ad
@@ -1667,6 +1667,7 @@ void BoxLockNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int reg    = ra_->get_encode(this);
 
   if (is_imm_in_range(offset, 12, 0)) {
+    // C-Ext: See BoxLockNode::size(). We need to manually calculate this node's size.
     __ addi_nc(as_Register(reg), sp, offset);
   } else if (is_imm_in_range(offset, 32, 0)) {
     __ li32(t0, offset);

--- a/src/hotspot/cpu/riscv64/riscv64.ad
+++ b/src/hotspot/cpu/riscv64/riscv64.ad
@@ -1164,14 +1164,15 @@ bool maybe_use_tmp_register_decoding_klass() {
 
 int MachCallStaticJavaNode::ret_addr_offset()
 {
-  // call should be a simple jal
-  int off = 4;
-  return off;
+  // jal
+  return 1 * NativeInstruction::instruction_size;
 }
 
 int MachCallDynamicJavaNode::ret_addr_offset()
 {
-  return 28; // movptr, jal
+  return 4 * NativeInstruction::instruction_size +
+         2 * (!UseCExt ? NativeInstruction::instruction_size : NativeInstruction::compressed_instruction_size) +
+         1 * NativeInstruction::instruction_size; // movptr, jal
 }
 
 int MachCallRuntimeNode::ret_addr_offset() {
@@ -1191,7 +1192,14 @@ int MachCallRuntimeNode::ret_addr_offset() {
   if (cb != NULL) {
     return 1 * NativeInstruction::instruction_size;
   } else {
-    return 12 * NativeInstruction::instruction_size;
+    const int instruction_size = NativeInstruction::instruction_size;
+    const int compressed_instruction_size = (!UseCExt ? instruction_size : NativeInstruction::compressed_instruction_size);
+    return 2 * instruction_size +
+           4 * instruction_size + 2 * compressed_instruction_size +
+           1 * compressed_instruction_size +
+           1 * compressed_instruction_size +
+           1 * compressed_instruction_size +
+           1 * compressed_instruction_size;
   }
 }
 
@@ -1234,7 +1242,7 @@ uint MachBreakpointNode::size(PhaseRegAlloc *ra_) const {
   }
 
   uint MachNopNode::size(PhaseRegAlloc*) const {
-    return _count * NativeInstruction::instruction_size;
+    return _count * (!UseCExt ? NativeInstruction::instruction_size : NativeInstruction::compressed_instruction_size);
   }
 
 //=============================================================================
@@ -1303,7 +1311,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  __ nop();
+  __ nop_nc();  // 4 bytes
 
   assert_cond(C != NULL);
 
@@ -1395,7 +1403,14 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   __ remove_frame(framesize);
 
   if (StackReservedPages > 0 && C->has_reserved_stack_access()) {
-    __ reserved_stack_check();
+    // C-Ext: we need to emit instructions of the same constant size here.
+    //   This Node will emit should_not_reach_here(), further emitting a movptr of pc() address.
+    //   However, C2 will do PhaseOutput::scratch_emit_size() to simulate the size of Node -
+    //   this time, the pc() is a different value from the final emission and it may get compressed.
+    //   We may get a case that Node size is different between scratch_emit and real emission phase,
+    //   which are not allowed. So we need to emit the same constant size by disabling compression
+    //   of the movptr of pc() to align with the logic.
+    __ reserved_stack_check(false);
   }
 
   if (do_polling() && C->is_method_compilation()) {
@@ -1652,7 +1667,7 @@ void BoxLockNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int reg    = ra_->get_encode(this);
 
   if (is_imm_in_range(offset, 12, 0)) {
-    __ addi(as_Register(reg), sp, offset);
+    __ addi_nc(as_Register(reg), sp, offset);
   } else if (is_imm_in_range(offset, 32, 0)) {
     __ li32(t0, offset);
     __ add(as_Register(reg), sp, t0);

--- a/src/hotspot/cpu/riscv64/riscv64.ad
+++ b/src/hotspot/cpu/riscv64/riscv64.ad
@@ -1180,14 +1180,14 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   jal(addr)
   // or with far branches
   //   jal(trampoline_stub)
-  // for real runtime callouts it will be six instructions
+  // for real runtime callouts it will be 12 instructions
   // see riscv64_enc_java_to_runtime
-  //   la(t1, retaddr)
-  //   la(t0, RuntimeAddress(addr))
-  //   addi(sp, sp, -2 * wordSize)
-  //   sd(zr, Address(sp))
-  //   sd(t1, Address(sp, wordSize))
-  //   jalr(t0)
+  //   la(t1, retaddr)                ->  auipc + addi
+  //   la(t0, RuntimeAddress(addr))   ->  lui + addi + slli(C) + addi + slli(C) + addi
+  //   addi(sp, sp, -2 * wordSize)    ->  addi(C)
+  //   sd(zr, Address(sp))            ->  sd(C)
+  //   sd(t1, Address(sp, wordSize))  ->  sd(C)
+  //   jalr(t0)                       ->  jalr(C)
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb != NULL) {
     return 1 * NativeInstruction::instruction_size;

--- a/src/hotspot/cpu/riscv64/sharedRuntime_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/sharedRuntime_riscv64.cpp
@@ -350,7 +350,7 @@ static void patch_callers_callsite(MacroAssembler *masm) {
   __ mv(c_rarg1, lr);
   int32_t offset = 0;
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::fixup_callers_callsite)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
 
   // Explicit fence.i required because fixup_callers_callsite may change the code
   // stream.
@@ -1082,7 +1082,7 @@ static void rt_call(MacroAssembler* masm, address dest) {
   } else {
     int32_t offset = 0;
     __ la_patchable(t0, RuntimeAddress(dest), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_nc(x1, t0, offset);
   }
 }
 
@@ -1208,7 +1208,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    __ nop();
+    __ nop_nc();
     gen_special_dispatch(masm,
                          method,
                          in_sig_bt,
@@ -1427,7 +1427,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  __ nop();
+  __ nop_nc();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {
     Label L_skip_barrier;
@@ -1995,7 +1995,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 #endif
     int32_t offset = 0;
     __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_nc(x1, t0, offset);
 
     // Restore any method result value
     restore_native_result(masm, ret_type, stack_slots);
@@ -2214,7 +2214,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ mv(c_rarg1, xcpool);
   int32_t offset = 0;
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::fetch_unroll_info)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
   __ bind(retaddr);
 
   // Need to have an oopmap that tells fetch_unroll_info where to
@@ -2352,7 +2352,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ mv(c_rarg1, xcpool); // second arg: exec_mode
   offset = 0;
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
 
   // Set an oopmap for the call site
   // Use the same PC we used for the last java frame
@@ -2440,7 +2440,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   __ la_patchable(t0,
         RuntimeAddress(CAST_FROM_FN_PTR(address,
                                         Deoptimization::uncommon_trap)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
   __ bind(retaddr);
 
   // Set an oopmap for the call site
@@ -2564,7 +2564,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   __ mvw(c_rarg1, (unsigned)Deoptimization::Unpack_uncommon_trap);
   offset = 0;
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
 
   // Set an oopmap for the call site
   // Use the same PC we used for the last java frame
@@ -2635,7 +2635,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
   __ mv(c_rarg0, xthread);
   int32_t offset = 0;
   __ la_patchable(t0, RuntimeAddress(call_ptr), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
   __ bind(retaddr);
 
   // Set an oopmap for the call site.  This oopmap will map all
@@ -2746,7 +2746,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
     __ mv(c_rarg0, xthread);
     int32_t offset = 0;
     __ la_patchable(t0, RuntimeAddress(destination), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_nc(x1, t0, offset);
     __ bind(retaddr);
   }
 
@@ -2887,7 +2887,7 @@ void OptoRuntime::generate_exception_blob() {
   __ mv(c_rarg0, xthread);
   int32_t offset = 0;
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, OptoRuntime::handle_exception_C)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_nc(x1, t0, offset);
 
 
   // handle_exception_C is a special VM call which does not require an explicit

--- a/src/hotspot/cpu/riscv64/vm_version_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/vm_version_riscv64.hpp
@@ -39,17 +39,27 @@ public:
 
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
+  // UseVExt
   static bool is_checkvext_fault(address pc) {
     return pc != NULL && pc == _checkvext_fault_pc;
   }
-
   static address continuation_for_checkvext_fault(address pc) {
     assert(_checkvext_continuation_pc != NULL, "not initialized");
     return _checkvext_continuation_pc;
   }
-
   static address _checkvext_fault_pc;
   static address _checkvext_continuation_pc;
+
+  // UseCExt
+  static bool is_checkcext_fault(address pc) {
+    return pc != NULL && pc == _checkcext_fault_pc;
+  }
+  static address continuation_for_checkcext_fault(address pc) {
+    assert(_checkcext_continuation_pc != NULL, "not initialized");
+    return _checkcext_continuation_pc;
+  }
+  static address _checkcext_fault_pc;
+  static address _checkcext_continuation_pc;
 
 protected:
   static int _initial_vector_length;

--- a/src/hotspot/os_cpu/linux_riscv64/os_linux_riscv64.cpp
+++ b/src/hotspot/os_cpu/linux_riscv64/os_linux_riscv64.cpp
@@ -279,6 +279,13 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       }
     }
 
+    if (sig == SIGILL && VM_Version::is_checkcext_fault(pc)) {
+      os::Posix::ucontext_set_pc(uc, VM_Version::continuation_for_checkcext_fault(pc));
+      warning("RVC is not supported on this CPU");
+      FLAG_SET_DEFAULT(UseCExt, false);
+      return true;
+    }
+
     if (sig == SIGILL && VM_Version::is_checkvext_fault(pc)) {
       os::Posix::ucontext_set_pc(uc, VM_Version::continuation_for_checkvext_fault(pc));
       return true;

--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -443,7 +443,7 @@ class PatchingStub: public CodeStub {
       NativeMovRegMem* n_move = nativeMovRegMem_at(pc_start());
       n_move->set_offset(field_offset);
       // Copy will never get executed, so only copy the part which is required for patching.
-      _bytes_to_copy = MAX2(n_move->num_bytes_to_end_of_patch(), (int)NativeGeneralJump::instruction_size);
+      _bytes_to_copy = MAX2(n_move->num_bytes_to_end_of_patch(), NOT_RISCV64((int)NativeGeneralJump::instruction_size) RISCV64_ONLY(NativeGeneralJump::get_instruction_size()));
     } else if (_id == load_klass_id || _id == load_mirror_id || _id == load_appendix_id) {
       assert(_obj != noreg, "must have register object for load_klass/load_mirror");
 #ifdef ASSERT

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -40,7 +40,7 @@ void LIR_Assembler::patching_epilog(PatchingStub* patch, LIR_PatchCode patch_cod
   // We must have enough patching space so that call can be inserted.
   // We cannot use fat nops here, since the concurrent code rewrite may transiently
   // create the illegal instruction sequence.
-  while ((intx) _masm->pc() - (intx) patch->pc_start() < NativeGeneralJump::instruction_size) {
+  while ((intx) _masm->pc() - (intx) patch->pc_start() < NOT_RISCV64(NativeGeneralJump::instruction_size) RISCV64_ONLY(NativeGeneralJump::get_instruction_size()) ) {
     _masm->nop();
   }
   patch->install(_masm, patch_code, obj, info);

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -329,7 +329,7 @@ JVMFlag::Error InteriorEntryAlignmentConstraintFunc(intx value, bool verbose) {
    }
 
   int minimum_alignment = 16;
-#if defined(X86) && !defined(AMD64)
+#if (defined(X86) && !defined(AMD64)) || defined(RISCV64)
   minimum_alignment = 4;
 #elif defined(S390)
   minimum_alignment = 2;


### PR DESCRIPTION
Hi team,

Could I have a review of this patch of compressed instructions support based on current implementation? Thanks in advance.

This patch can introduce:
* 4.4% performance up on average, evaluated on SPECjbb2005 and SPECjbb2015
* 21% code size reduction in template interpreter generated code
* 20%~25% code size reduction in C1 generated code, evaluated by a common SpringBoot program
* 15%~20% code size reduction in C2 generated code, evaluated by a common SpringBoot program

Having passed related tests based on the current code base.

There are things about this patch:
1. It is an implicit phase to scan all assembly instructions generated by `Assembler::emit()` and convert them as they can into compressed instructions - it should be because it is somewhat C-Ext's semantics and we cannot change instructions written by programmers explicitly one by one.
2. About the `_nc` postfix of some of Assembler instructions: we know a bunch of places should be reserved for patching, where we cannot change them into compressed instructions. `_nc` is short for `not compressed` - with this, that instruction should keep its origin 4-byte form and remain uncompressed.
3. About whether a machine supports c-ext and autodetection: please see [this](https://github.com/riscv/riscv-isa-sim/issues/710). It seems that we need to use a compressed instruction to test if it supports C-Ext or not. This part of the logic is what I cannot test because: we do not have a machine that does not support C-Ext; Qemu seems not able to easily turn off C-Ext as I see, and Spike behaves a bit weird for it will turn to a dead loop or something if you write a compressed instruction but run the simulator without C-Ext. I only tested it with a SIGILL to protect its function.
4. There are things not easy to compress like `MachBranchNode`s. Please see the comments in my code - but it seems no potential benefits for compressing these `MachBranchNode`s after we have done some work for this so we can directly disable compression of these instructions until we think of a better plan. We think it is not trivial to support this.

This patch may not be a small one so it may take a while to get merged or something - but I was kind of hoping this could be done before the next merge, which contains the biased lock removal and stuff. Hope everything safe.

Thanks again for your great work.
Xiaolin