### PR TITLE
Port missing trampoline logic from AArch64 platform

### DIFF
--- a/src/hotspot/cpu/riscv64/nativeInst_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/nativeInst_riscv64.cpp
@@ -147,8 +147,12 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
   }
 
   // Patch the call.
-  guarantee(trampoline_stub_addr != NULL, "we need a trampoline");
-  set_destination(trampoline_stub_addr);
+  if (Assembler::reachable_from_branch_at(addr_call, dest)) {
+    set_destination(dest);
+  } else {
+    assert (trampoline_stub_addr != NULL, "we need a trampoline");
+    set_destination(trampoline_stub_addr);
+  }
 
   ICache::invalidate_range(addr_call, instruction_size);
 }


### PR DESCRIPTION
Hi team,

When we were doing some trampoline stub optimizations, we found that some logic of trampoline patching was missing. Lots of calls jump to the trampoline stub at first even if the target address is directly reachable by using a simple `jal`. After adding back the logic from the AArch64 platform, we find a nearly 4% performance enhancement on SPECjbb2005/15. Also, jtreg tests are passed.

Thanks,
Xiaolin