### PR TITLE
Fix cmpxchg narrow values: need to sign-extend non-bool results

### DIFF
--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
@@ -2333,6 +2333,12 @@ void MacroAssembler::cmpxchg_narrow_value(Register addr, Register expected,
 
     bind(fail);
     srl(result, tmp, shift);
+
+    if (size == int8) {
+      sign_ext(result, result, registerSize - 8);
+    } else if (size == int16) {
+      sign_ext(result, result, registerSize - 16);
+    }
   }
 }
 


### PR DESCRIPTION
Hi team,

We may need to sign-extend non-bool results if the result is a negative value - just a minor fix.
[The test reproducing the issue](https://gist.github.com/zhengxiaolinX/2fbcf25bbecb464c3fba50a89f814fa0)
Have tested with full jtreg tests.

Thanks,
Xiaolin