### PR TITLE
Fix store condition: instruction has wrong operand order

### DIFF
--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
@@ -2690,7 +2690,7 @@ void MacroAssembler::atomic_incw(Register counter_addr, Register tmp) {
   lr_w(tmp, counter_addr);
   addw(tmp, tmp, 1);
   // if we store+flush with no intervening write tmp wil be zero
-  sc_w(tmp, counter_addr, tmp);
+  sc_w(tmp, tmp, counter_addr);
   bnez(tmp, retry_load);
 }
 


### PR DESCRIPTION
Hi team,

This is a trivial fix for an issue reproduced by using `PrintBiasedLockingStatistics`. Though this option is getting removed in the next merge and the `atomic_incw` is only used to atomically set a value of a counter variable currently, I assume this basic function `atomic_incw` may get remained for future use, so a fix might be needed. Tested in all cases.

Thanks,
Xiaolin