### PR TITLE
[MacroAssembler] Add MacroAssembler::bind(Label) for riscv64

### DIFF
--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.hpp
@@ -517,6 +517,12 @@ class MacroAssembler: public Assembler {
   // if heap base register is used - reinit it with the correct value
   void reinit_heapbase();
 
+  void bind(Label& L) {
+    Assembler::bind(L);
+    // fences across basic blocks should not be merged
+    code()->clear_last_insn();
+  }
+
   // mv
   void mv(Register Rd, int64_t imm64);
   void mv(Register Rd, int imm);


### PR DESCRIPTION
Hi all,

RISC-V port supports merging membar, which should not merge fences across basic blocks. `MacroAssembler::bind(Label)` clears `_last_insn` to avoid merging binded fences.  

jtreg tests are passed.

Thanks,
Feilong