### PR TITLE
[String intrinsic] Add string intrinsic string_indexof_char

### DIFF
--- a/src/hotspot/cpu/riscv64/c2_MacroAssembler_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/c2_MacroAssembler_riscv64.hpp
@@ -42,6 +42,16 @@
                       Register tmp1, Register tmp2, Register tmp3,
                       int ae);
 
+  void string_indexof_char_short(Register str1, Register cnt1,
+                                 Register ch, Register result,
+                                 bool isL);
+
+  void string_indexof_char(Register str1, Register cnt1,
+                           Register ch, Register result,
+                           Register tmp1, Register tmp2,
+                           Register tmp3, Register tmp4,
+                           bool isL);
+
   void string_indexof(Register str1, Register str2,
                       Register cnt1, Register cnt2,
                       Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/riscv64/globals_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/globals_riscv64.hpp
@@ -94,5 +94,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Extend i for r and o for w in the pred/succ flags of fence;" \
           "Extend fence.i to fence.i + fence.")                         \
   product(bool, UseVExt, false, "Use RVV instructions")                 \
+  product(bool, AvoidUnalignedAccesses, true,                           \
+          "Avoid generating unaligned memory accesses")                 \
 
 #endif // CPU_RISCV64_GLOBALS_RISCV64_HPP

--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
@@ -3236,16 +3236,16 @@ void MacroAssembler::oop_bne(Register obj1, Register obj2, Label& L_nequal, bool
 }
 
 // string indexof
-// compute index by tailing zeros
-void MacroAssembler::compute_index(Register haystack, Register tailing_zero,
+// compute index by trailing zeros
+void MacroAssembler::compute_index(Register haystack, Register trailing_zero,
                                    Register match_mask, Register result,
                                    Register ch2, Register tmp,
                                    bool haystack_isL)
 {
   int haystack_chr_shift = haystack_isL ? 0 : 1;
-  srl(match_mask, match_mask, tailing_zero);
+  srl(match_mask, match_mask, trailing_zero);
   srli(match_mask, match_mask, 1);
-  srli(tmp, tailing_zero, LogBitsPerByte);
+  srli(tmp, trailing_zero, LogBitsPerByte);
   if (!haystack_isL) andi(tmp, tmp, 0xE);
   add(haystack, haystack, tmp);
   ld(ch2, Address(haystack));
@@ -3254,7 +3254,13 @@ void MacroAssembler::compute_index(Register haystack, Register tailing_zero,
 }
 
 // string indexof
-// find pattern element in src, compute match mask
+// find pattern element in src, compute match mask,
+// only the first occurrence of 0x80/0x8000 at low bits is the valid match index
+// match mask patterns and corresponding indices would be like:
+// - 0x8080808080808080 (Latin1)
+// -   7 6 5 4 3 2 1 0  (match index)
+// - 0x8000800080008000 (UTF16)
+// -   3   2   1   0    (match index)
 void MacroAssembler::compute_match_mask(Register src, Register pattern, Register match_mask,
                                         Register mask1, Register mask2)
 {
@@ -3265,25 +3271,10 @@ void MacroAssembler::compute_match_mask(Register src, Register pattern, Register
   andr(match_mask, match_mask, src);
 }
 
-void MacroAssembler::ctz_bit(Register Rd, Register Rs, Register Rtmp1, Register Rtmp2)
-{
-  assert_different_registers(Rd, Rs, Rtmp1, Rtmp2);
-  Label Loop;
-  int step = 1;
-  li(Rd, -1);
-  mv(Rtmp2, Rs);
-
-  bind(Loop);
-  addi(Rd, Rd, 1);
-  andi(Rtmp1, Rtmp2, ((1 << step) - 1));
-  srli(Rtmp2, Rtmp2, 1);
-  beqz(Rtmp1, Loop);
-}
-
-// This instruction counts zero bits from lsb to msb until first non-zero element.
+// count bits of trailing zero chars from lsb to msb until first non-zero element.
 // For LL case, one byte for one element, so shift 8 bits once, and for other case,
 // shift 16 bits once.
-void MacroAssembler::ctz(Register Rd, Register Rs, bool isLL, Register Rtmp1, Register Rtmp2)
+void MacroAssembler::ctzc_bit(Register Rd, Register Rs, bool isLL, Register Rtmp1, Register Rtmp2)
 {
   assert_different_registers(Rd, Rs, Rtmp1, Rtmp2);
   Label Loop;

--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.hpp
@@ -678,7 +678,7 @@ class MacroAssembler: public Assembler {
   void oop_beq(Register obj1, Register obj2, Label& L_equal, bool is_far = false);
   void oop_bne(Register obj1, Register obj2, Label& L_nequal, bool is_far = false);
 
-  void compute_index(Register str1, Register tailing_zero, Register match_mask,
+  void compute_index(Register str1, Register trailing_zero, Register match_mask,
                      Register result, Register char_tmp, Register tmp,
                      bool haystack_isL);
   void compute_match_mask(Register src, Register pattern, Register match_mask,
@@ -687,8 +687,7 @@ class MacroAssembler: public Assembler {
   void inflate_lo32(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);
   void inflate_hi32(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);
 
-  void ctz(Register Rd, Register Rs, bool isLL = false, Register Rtmp1 = t0, Register Rtmp2 = t1);
-  void ctz_bit(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);
+  void ctzc_bit(Register Rd, Register Rs, bool isLL = false, Register Rtmp1 = t0, Register Rtmp2 = t1);
 
   void zero_words(Register base, u_int64_t cnt);
   address zero_words(Register ptr, Register cnt);

--- a/src/hotspot/cpu/riscv64/riscv64.ad
+++ b/src/hotspot/cpu/riscv64/riscv64.ad
@@ -1774,7 +1774,6 @@ const bool Matcher::match_rule_supported(int opcode) {
       break;
     case Op_StrCompressedCopy: // fall through
     case Op_StrInflatedCopy:   // fall through
-    case Op_StrIndexOfChar:    // fall through
     case Op_HasNegatives:
       return UseVExt;
     case Op_EncodeISOArray:
@@ -10048,6 +10047,45 @@ instruct string_indexof_conUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2,
                                  $tmp1$$Register, $tmp2$$Register,
                                  $tmp3$$Register, $tmp4$$Register,
                                  icnt2, $result$$Register, StrIntrinsicNode::UL);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct stringU_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
+                              iRegI_R10 result, iRegINoSp tmp1, iRegINoSp tmp2,
+                              iRegINoSp tmp3, iRegINoSp tmp4, iRegL_R6 tmp)
+%{
+  match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
+  predicate(!UseVExt && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
+  effect(USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP_DEF result,
+         TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL tmp);
+
+  format %{ "StringUTF16 IndexOf char[] $str1,$cnt1,$ch -> $result" %}
+
+  ins_encode %{
+    __ string_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register,
+                           $result$$Register, $tmp1$$Register, $tmp2$$Register,
+                           $tmp3$$Register, $tmp4$$Register, false /* isU */) ;
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+
+instruct stringL_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
+                              iRegI_R10 result, iRegINoSp tmp1, iRegINoSp tmp2,
+                              iRegINoSp tmp3, iRegINoSp tmp4, iRegL_R6 tmp)
+%{
+  match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
+  predicate(!UseVExt && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
+  effect(USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP_DEF result,
+         TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL tmp);
+
+  format %{ "StringUTF16 IndexOf char[] $str1,$cnt1,$ch -> $result" %}
+
+  ins_encode %{
+    __ string_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register,
+                           $result$$Register, $tmp1$$Register, $tmp2$$Register,
+                           $tmp3$$Register, $tmp4$$Register, true /* isL */);
   %}
   ins_pipe(pipe_class_memory);
 %}

--- a/src/hotspot/cpu/riscv64/vm_version_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/vm_version_riscv64.cpp
@@ -206,6 +206,10 @@ void VM_Version::get_processor_features() {
     UseVExt = true;
   }
 
+  if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
+    FLAG_SET_DEFAULT(AvoidUnalignedAccesses, true);
+  }
+
 #ifdef COMPILER2
   get_c2_processor_features();
 #endif // COMPILER2


### PR DESCRIPTION
Hi team,
This patch introduces a new string intrinsic string_indexof_char and the new option 'AvoidUnalignedAccesses'. We found that the performance degradation of unaligned accesses on current RISC-V hardware (HiFive Unleashed, for example) was significant compared to aligned accesses.

We have run JMH test  on HiFive Unleashed with the length of 64 random generated Latin1 string and the `indexOf()` index various from 0 to 7, the performance improvement shows as below (throughput mode, the higher the better):

| Benchmark| Score(Aligned)| Score(Unaligned)|
|--|--|--|
|latin1Len0064Char| 2.775|2.769|
|latin1Len0064CharWithIndex1|2.402|0.153|
|latin1Len0064CharWithIndex2|2.498|0.15|
|latin1Len0064CharWithIndex3|2.404|0.154|
|latin1Len0064CharWithIndex4|2.564|0.151|
|latin1Len0064CharWithIndex5|2.546|0.154|
|latin1Len0064CharWithIndex6|2.609|0.156|
|latin1Len0064CharWithIndex7|2.612|0.156|

The only difference between **Aligned** and **Unaligned** is whether the "AvoidUnalignedAccesses" option is enabled. jtreg tests are passed.

Thanks,
Feilong