### PR TITLE
[Misc] Align up InlineSmallCode size with AArch64

### DIFF
--- a/src/hotspot/cpu/riscv64/globals_riscv64.hpp
+++ b/src/hotspot/cpu/riscv64/globals_riscv64.hpp
@@ -72,7 +72,7 @@ define_pd_global(bool, CompactStrings, true);
 // Clear short arrays bigger than one word in an arch-specific way
 define_pd_global(intx, InitArrayShortSize, BytesPerLong);
 
-define_pd_global(intx, InlineSmallCode,          1000);
+define_pd_global(intx, InlineSmallCode,          2500);
 
 #define ARCH_FLAGS(develop,                                             \
                    product,                                             \

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -380,7 +380,7 @@ void CompilerConfig::set_compilation_policy_flags() {
     }
 #endif
 
-#if defined AARCH64 || defined RISCV64
+#if defined AARCH64
     if (FLAG_IS_DEFAULT(InlineSmallCode)) {
       FLAG_SET_DEFAULT(InlineSmallCode, 2500);
     }

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -380,7 +380,7 @@ void CompilerConfig::set_compilation_policy_flags() {
     }
 #endif
 
-#if defined AARCH64
+#if defined AARCH64 || defined RISCV64
     if (FLAG_IS_DEFAULT(InlineSmallCode)) {
       FLAG_SET_DEFAULT(InlineSmallCode, 2500);
     }


### PR DESCRIPTION
Hi team,

This is a trivial aligning up to AArch64's configuration. Springboot's `already compiled into a big method` count in `PrintInlining` is reduced from 119 to 46.

Thanks,
Xiaolin