### PR TITLE
[LIRAssembler] typo in LIR_Assembler::emit_profile_type

### DIFF
--- a/src/hotspot/cpu/riscv64/c1_LIRAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_LIRAssembler_riscv64.cpp
@@ -1664,7 +1664,7 @@ void LIR_Assembler::check_no_conflict(ciKlass* exact_klass, intptr_t current_kla
   }
 #endif
     // first time here. Set profile type.
-    __ ld(tmp, mdo_addr);
+    __ sd(tmp, mdo_addr);
   } else {
     assert(ciTypeEntries::valid_ciklass(current_klass) != NULL &&
            ciTypeEntries::valid_ciklass(current_klass) != exact_klass, "inconsistent");


### PR DESCRIPTION
From commit 9175a8d2178
