### PR TITLE
[C-Ext] Fix patchable `jal`s spanning cache lines

### DIFF
--- a/src/hotspot/cpu/riscv64/c1_LIRAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/c1_LIRAssembler_riscv64.cpp
@@ -1334,7 +1334,12 @@ void LIR_Assembler::comp_fl2i(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Op
   }
 }
 
-void LIR_Assembler::align_call(LIR_Code code) {  }
+void LIR_Assembler::align_call(LIR_Code code) {
+  // C-Ext: With C-Ext a call may get 2-byte aligned.
+  //   the address of jal itself (which will be patched later) should not span the cache line.
+  //   See CallDynamicJavaDirectNode::compute_padding() for more info.
+  __ align(4);
+}
 
 void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
   address call = __ trampoline_call(Address(op->addr(), rtype));

--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
@@ -2762,7 +2762,7 @@ void MacroAssembler::far_call(Address entry, CodeBuffer *cbuf, Register tmp) {
     jalr_nc(x1, tmp, offset); // link
   } else {
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
-    jal(entry); // link
+    jal_nc(entry); // link
   }
 }
 

--- a/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
+++ b/src/hotspot/cpu/riscv64/macroAssembler_riscv64.cpp
@@ -3193,7 +3193,9 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
 
   // make sure 4 byte aligned here, so that the destination address would be
   // 8 byte aligned after 3 intructions
-  while (offset() % wordSize == 0) { nop(); }
+  // C-Ext: when we reach here we may get a 2-byte alignment and
+  //   nop() will be 2 bytes in length.
+  while (offset() % wordSize != 4) { nop(); }
 
   relocate(trampoline_stub_Relocation::spec(code()->insts()->start() +
                                             insts_call_instruction_offset));
@@ -3208,6 +3210,7 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
   bind(target);
   assert(offset() - stub_start_offset == NativeCallTrampolineStub::data_offset,
          "should be");
+  assert(offset() % wordSize == 0, "address loaded by ld must be 8-byte aligned under riscv64");
   emit_int64((intptr_t)dest);
 
   const address stub_start_addr = addr_at(stub_start_offset);

--- a/src/hotspot/cpu/riscv64/riscv64.ad
+++ b/src/hotspot/cpu/riscv64/riscv64.ad
@@ -1208,6 +1208,41 @@ int MachCallNativeNode::ret_addr_offset() {
   return -1;
 }
 
+// C-Ext: With C-Ext a call may get 2-byte aligned.
+//   The offset encoding in jal ranges bits [12, 31], which could span the cache line.
+//   Patching this unaligned address will make the write operation not atomic.
+//   Other threads may be running the same piece of code at full speed, causing concurrency issues.
+//   So we must ensure that it does not span a cache line so that it can be patched.
+int CallStaticJavaDirectNode::compute_padding(int current_offset) const
+{
+  // to make sure the address of jal 4-byte aligned.
+  return align_up(current_offset, alignment_required()) - current_offset;
+}
+
+// C-Ext: With C-Ext a call may get 2-byte aligned.
+//   The offset encoding in jal ranges bits [12, 31], which could span the cache line.
+//   Patching this unaligned address will make the write operation not atomic.
+//   Other threads may be running the same piece of code at full speed, causing concurrency issues.
+//   So we must ensure that it does not span a cache line so that it can be patched.
+int CallDynamicJavaDirectNode::compute_padding(int current_offset) const
+{
+  // skip the movptr in MacroAssembler::ic_call():
+  // lui + addi + slli(C) + addi + slli(C) + addi
+  // Though movptr() has already 4-byte aligned with or without C-Ext,
+  // We need to prevent from further changes by explicitly calculating the size.
+  const int instruction_size = NativeInstruction::instruction_size;
+  const int compressed_instruction_size = (!UseCExt ? instruction_size : NativeInstruction::compressed_instruction_size);
+  const int movptr_size =
+         2 * instruction_size +
+         1 * compressed_instruction_size +
+         1 * instruction_size +
+         1 * compressed_instruction_size +
+         1 * instruction_size;
+  current_offset += movptr_size;
+  // to make sure the address of jal 4-byte aligned.
+  return align_up(current_offset, alignment_required()) - current_offset;
+}
+
 //=============================================================================
 
 #ifndef PRODUCT
@@ -9760,6 +9795,7 @@ instruct CallStaticJavaDirect(method meth)
               riscv64_enc_call_epilog );
 
   ins_pipe(pipe_class_call);
+  ins_alignment(4);
 %}
 
 // TO HERE
@@ -9779,6 +9815,7 @@ instruct CallDynamicJavaDirect(method meth, iRegL_R6 cr)
                riscv64_enc_call_epilog );
 
   ins_pipe(pipe_class_call);
+  ins_alignment(4);
 %}
 
 // Call Runtime Instruction


### PR DESCRIPTION
Hi team,

This patch includes several fixes for the C extension support. It contains three small patches to fix different problems or potential issues. 

1. As @yadongw has suggested, `MacroAssembler::far_call()` has a reserved place needing a fix. Though hardly reachable, for its correctness we also need to fix it.
2. After supporting the C extension, instructions become 2-byte aligned - also for trampolines. In order to make the `emit_int64((intptr_t)dest)` 8-byte aligned, some code needs a revise to adjust the new change. We have checked places where unalignment-related issues could occur and found this one, and now the 64-bit addresses in trampolines are properly aligned.
3. The third issue is a crash which is a bit hard to address, only happening by using the C extension. 
Please see a [hs_err file](https://gist.github.com/zhengxiaolinX/62613c13c210b5798a89b3f7c804a193) attached.
In short, patchable instructions' patching bits must not span cache lines. Concisely, the problem is that, after the C extension instructions get 2-byte aligned. Patchable `jal`s are remaining their 4-byte form, but now they might stay in a 2-byte alignment.
An example:
```
0x0000003fe11b01fe:   jal	ra,0x0000003fe1126d80 (patchable)
0x0000003fe11b0202:   ...
```

Code is running at full speed on every hart. If this instruction is patched with unaligned access, the patching operation is not atomic anymore. In this respect, concurrency issues may occur, which are hard to address as `pc`s could fly to any place and the generated code seems to have no error.
We solve this issue by using `ins_alignment(4)` to force the patchable jals to stay in a 4-byte aligned address.
```
0x0000003fe11b0200:   jal	ra,0x0000003fe1126d80 (patchable)
0x0000003fe11b0204:   ...
```


Jtreg tests
```
com/sun/jdi/EnumTest.java
com/sun/jdi/RedefineCrossStart.java
java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java
java/util/stream/test/org/openjdk/tests/java/util/stream/mapMultiOpTest.java
java/util/ResourceBundle/Control/StressTest.java
java/nio/charset/coders/BashCache.java
java/nio/channels/AsynchronousSocketChannel/StressLoopback.java
java/net/HugeDataTransferTest.java
java/net/httpclient/LargeResponseTest.java
```
could reproduce this issue in small chances.

I have run these tests over nights to ensure the issue is solved. Also, other jtreg tests are passed.

Thanks,
Xiaolin